### PR TITLE
feat: added worker entity with generic support

### DIFF
--- a/.github/workflows/backward-compatibility.yml
+++ b/.github/workflows/backward-compatibility.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.23'
 
       - name: Run Backward Compatibility Tests
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.23'
 
       - name: Install dependencies
         run: go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.23 AS build
 RUN mkdir /package
 COPY /sdk /package/sdk
 COPY /go.mod /package/go.mod
@@ -7,8 +7,11 @@ WORKDIR /package
 RUN go build -v ./...
 
 FROM build as test
-COPY /test /package/test
-RUN go test -v $(go list ./... | grep -v /test/integration_tests)
+COPY /test/unit_tests /package/test/unit_tests
+# Run SDK unit tests
+RUN go test -v -race ./sdk/...
+# Run additional unit tests
+RUN go test -v -race ./test/unit_tests/...
 
 FROM build as inttest
 COPY /test /package/test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/conductor-sdk/conductor-go
 
-go 1.17
+go 1.23
 
 require (
 	github.com/antihax/optional v1.0.0

--- a/sdk/worker/bind.go
+++ b/sdk/worker/bind.go
@@ -1,0 +1,36 @@
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+//  the License. You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations under the License.
+
+package worker
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// InputBinder performs conversion of Conductor task input (map[string]any) into a typed destination value.
+type InputBinder interface {
+	Bind(dst any, src map[string]any) error
+}
+
+// JSONBinder implements InputBinder via JSON marshal/unmarshal.
+type JSONBinder struct{}
+
+// Bind converts the provided task input map into the destination typed value using JSON marshal/unmarshal.
+// The dst parameter must be a non-nil pointer to the destination type.
+func (JSONBinder) Bind(dst any, src map[string]any) error {
+	if dst == nil {
+		return fmt.Errorf("destination pointer is nil - cannot bind task input")
+	}
+	raw, err := json.Marshal(src)
+	if err != nil {
+		return fmt.Errorf("failed to marshal input data: %w", err)
+	}
+	return json.Unmarshal(raw, dst)
+}

--- a/sdk/worker/context.go
+++ b/sdk/worker/context.go
@@ -1,0 +1,68 @@
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+//  the License. You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations under the License.
+
+package worker
+
+import (
+	"context"
+
+	"github.com/conductor-sdk/conductor-go/sdk/model"
+)
+
+// TaskContext extends context.Context with Conductor task/workflow metadata.
+type TaskContext interface {
+	context.Context
+	GetWorkflowInstanceID() string
+	GetWorkflowType() string
+	GetTaskID() string
+	GetTaskType() string
+	GetRetryCount() int
+	GetRetriedTaskID() string
+	GetPollCount() int
+}
+
+type workflowContext struct {
+	context.Context
+	workflowInstanceID string
+	workflowType       string
+	taskID             string
+	taskType           string
+	retryCount         int
+	retriedTaskID      string
+	pollCount          int
+}
+
+func (w *workflowContext) GetWorkflowInstanceID() string { return w.workflowInstanceID }
+func (w *workflowContext) GetWorkflowType() string       { return w.workflowType }
+func (w *workflowContext) GetTaskID() string             { return w.taskID }
+func (w *workflowContext) GetTaskType() string           { return w.taskType }
+func (w *workflowContext) GetRetryCount() int            { return w.retryCount }
+func (w *workflowContext) GetRetriedTaskID() string      { return w.retriedTaskID }
+func (w *workflowContext) GetPollCount() int             { return w.pollCount }
+
+// getWorkflowContext builds a TaskContext with enriched metadata from a model.Task.
+// The context.Context parameter should be the first parameter as per Go conventions.
+func getWorkflowContext(parent context.Context, t *model.Task) TaskContext {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if t == nil {
+		return &workflowContext{Context: parent}
+	}
+	return &workflowContext{
+		Context:            parent,
+		workflowInstanceID: t.WorkflowInstanceId,
+		workflowType:       t.WorkflowType,
+		taskID:             t.TaskId,
+		taskType:           t.TaskDefName,
+		retryCount:         int(t.RetryCount),
+		retriedTaskID:      t.RetriedTaskId,
+		pollCount:          int(t.PollCount),
+	}
+}

--- a/sdk/worker/doc.go
+++ b/sdk/worker/doc.go
@@ -1,0 +1,5 @@
+// Package worker provides primitives to register and run Conductor workers.
+//
+// It includes a configurable base `Worker`, a `TaskRunner` that polls and
+// executes tasks.
+package worker

--- a/sdk/worker/options.go
+++ b/sdk/worker/options.go
@@ -1,0 +1,47 @@
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+//  the License. You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations under the License.
+
+package worker
+
+import "time"
+
+// Option defines a functional option for configuring a Worker.
+type Option func(*Worker)
+
+// WithBatchSize sets the number of tasks to fetch per poll for the worker.
+func WithBatchSize(size int) Option {
+	return func(w *Worker) {
+		if size > 0 {
+			w.batchSize = size
+		}
+	}
+}
+
+// WithPollInterval sets the polling interval for the worker.
+func WithPollInterval(interval time.Duration) Option {
+	return func(w *Worker) {
+		if interval > 0 {
+			w.pollInterval = interval
+		}
+	}
+}
+
+// WithPollTimeout sets the polling timeout for the worker. Negative values mean server default.
+func WithPollTimeout(timeout time.Duration) Option {
+	return func(w *Worker) {
+		w.pollTimeout = timeout
+	}
+}
+
+// WithDomain sets the task domain for the worker.
+func WithDomain(domain string) Option {
+	return func(w *Worker) {
+		w.domain = domain
+	}
+}

--- a/sdk/worker/options_test.go
+++ b/sdk/worker/options_test.go
@@ -1,0 +1,134 @@
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+//  the License. You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations under the License.
+
+package worker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/conductor-sdk/conductor-go/sdk/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOption_WithBatchSize_SetsOnlyPositive(t *testing.T) {
+	var w Worker
+	w.batchSize = 99
+
+	WithBatchSize(-1)(&w)
+	assert.Equal(t, 99, w.batchSize, "negatives ignored")
+
+	WithBatchSize(0)(&w)
+	assert.Equal(t, 99, w.batchSize, "zero ignored")
+
+	WithBatchSize(1)(&w)
+	assert.Equal(t, 1, w.batchSize)
+
+	WithBatchSize(5)(&w)
+	assert.Equal(t, 5, w.batchSize, "last wins")
+}
+
+func TestOption_WithPollInterval_SetsOnlyPositive(t *testing.T) {
+	var w Worker
+	w.pollInterval = 987 * time.Millisecond
+
+	WithPollInterval(-10 * time.Millisecond)(&w)
+	assert.Equal(t, 987*time.Millisecond, w.pollInterval, "negatives ignored")
+
+	WithPollInterval(0)(&w)
+	assert.Equal(t, 987*time.Millisecond, w.pollInterval, "zero ignored")
+
+	WithPollInterval(50 * time.Millisecond)(&w)
+	assert.Equal(t, 50*time.Millisecond, w.pollInterval)
+}
+
+func TestOption_WithPollTimeout_SetsAnyValue(t *testing.T) {
+	var w Worker
+	w.pollTimeout = 111 * time.Millisecond
+
+	WithPollTimeout(0)(&w) // допускается
+	assert.Equal(t, 0*time.Millisecond, w.pollTimeout)
+
+	WithPollTimeout(-1 * time.Second)(&w) // «server default» по договорённости
+	assert.Equal(t, -1*time.Second, w.pollTimeout)
+
+	WithPollTimeout(250 * time.Millisecond)(&w)
+	assert.Equal(t, 250*time.Millisecond, w.pollTimeout)
+}
+
+func TestOption_WithDomain_SetsAsIs(t *testing.T) {
+	var w Worker
+	w.domain = "old"
+
+	WithDomain("")(&w)
+	assert.Equal(t, "", w.domain)
+
+	WithDomain("testing")(&w)
+	assert.Equal(t, "testing", w.domain)
+
+	WithDomain("  spaced  ")(&w)
+	assert.Equal(t, "  spaced  ", w.domain, "no trimming in option")
+}
+
+func TestOptions_Composition_OrderMatters(t *testing.T) {
+	var w Worker
+	WithBatchSize(1)(&w)
+	WithBatchSize(10)(&w) // последняя выигрывает
+	assert.Equal(t, 10, w.batchSize)
+
+	WithPollInterval(10 * time.Millisecond)(&w)
+	WithPollInterval(25 * time.Millisecond)(&w)
+	assert.Equal(t, 25*time.Millisecond, w.pollInterval)
+}
+
+func TestNewWorker_AppliesOptions(t *testing.T) {
+	w := NewWorker(
+		"opt_task",
+		func(tk *model.Task) (any, error) { return "ok", nil },
+		WithBatchSize(3),
+		WithPollInterval(123*time.Millisecond),
+		WithPollTimeout(-1*time.Second),
+		WithDomain("testing"),
+	)
+
+	assert.Equal(t, 3, w.batchSize)
+	assert.Equal(t, 123*time.Millisecond, w.pollInterval)
+	assert.Equal(t, -1*time.Second, w.pollTimeout)
+	assert.Equal(t, "testing", w.domain)
+}
+
+func TestNewTypedWorker_AppliesOptions_ToBase(t *testing.T) {
+	type In struct {
+		A int `json:"a"`
+	}
+	type Out struct {
+		B int `json:"b"`
+	}
+
+	tw := NewTypedWorker[In, Out](
+		"typed_opt",
+		func(ctx TaskContext, in In) (Out, error) { return Out{B: in.A}, nil },
+		WithBatchSize(7),
+		WithPollInterval(42*time.Millisecond),
+		WithPollTimeout(5*time.Second),
+		WithDomain("typed-domain"),
+	)
+
+	assert.Equal(t, 7, tw.base.batchSize)
+	assert.Equal(t, 42*time.Millisecond, tw.base.pollInterval)
+	assert.Equal(t, 5*time.Second, tw.base.pollTimeout)
+	assert.Equal(t, "typed-domain", tw.base.domain)
+
+	w := tw.Worker()
+	assert.NotSame(t, tw.base, w)
+	assert.Equal(t, 7, w.batchSize)
+	assert.Equal(t, 42*time.Millisecond, w.pollInterval)
+	assert.Equal(t, 5*time.Second, w.pollTimeout)
+	assert.Equal(t, "typed-domain", w.domain)
+}

--- a/sdk/worker/worker.go
+++ b/sdk/worker/worker.go
@@ -1,0 +1,62 @@
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+//  the License. You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations under the License.
+
+package worker
+
+import (
+	"time"
+
+	"github.com/conductor-sdk/conductor-go/sdk/model"
+)
+
+// Worker represents a configurable worker definition that can be registered with TaskRunner.
+// This entity enables an options pattern for configuration.
+type Worker struct {
+	taskName string
+	handler  model.ExecuteTaskFunction
+
+	batchSize    int
+	pollInterval time.Duration
+	pollTimeout  time.Duration
+	domain       string
+
+	binder InputBinder
+}
+
+// Provider exposes a Worker instance for registration with a TaskRunner.
+// It is implemented by types that can provide a base Worker (e.g., Worker and TypedWorker).
+type Provider interface{ Worker() *Worker }
+
+// NewWorker constructs a Worker.
+func NewWorker(taskName string, f func(t *model.Task) (interface{}, error), options ...Option) *Worker {
+	w := newBaseWorker(taskName, options...)
+	w.handler = f
+	return w
+}
+
+// newBaseWorker initializes a Worker with default configuration.
+func newBaseWorker(taskName string, options ...Option) *Worker {
+	w := &Worker{
+		taskName:     taskName,
+		batchSize:    1,
+		pollInterval: 500 * time.Millisecond,
+		pollTimeout:  -1 * time.Millisecond,
+		domain:       "",
+		binder:       JSONBinder{},
+	}
+	for _, opt := range options {
+		if opt != nil {
+			opt(w)
+		}
+	}
+	return w
+}
+
+// Worker allows base Worker to satisfy the Provider interface used by registration.
+func (w *Worker) Worker() *Worker { return w }

--- a/sdk/worker/worker_test.go
+++ b/sdk/worker/worker_test.go
@@ -1,0 +1,87 @@
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+//  the License. You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations under the License.
+
+package worker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/conductor-sdk/conductor-go/sdk/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBaseWorker_Defaults(t *testing.T) {
+	w := newBaseWorker("t")
+	assert.Equal(t, "t", w.taskName)
+	assert.Equal(t, 1, w.batchSize)
+	assert.Equal(t, 500*time.Millisecond, w.pollInterval)
+	assert.Equal(t, -1*time.Millisecond, w.pollTimeout)
+	assert.Equal(t, "", w.domain)
+
+	_, isJSON := w.binder.(JSONBinder)
+	assert.True(t, isJSON)
+}
+
+func TestNewWorker_SetsHandlerAndName(t *testing.T) {
+	called := false
+	h := func(tk *model.Task) (interface{}, error) {
+		called = true
+		return "ok", nil
+	}
+	w := NewWorker("taskA", h)
+
+	assert.Equal(t, "taskA", w.taskName)
+	out, err := w.handler(&model.Task{TaskDefName: "taskA"})
+	assert.NoError(t, err)
+	assert.Equal(t, "ok", out)
+	assert.True(t, called)
+}
+
+func TestOptions_IgnoreInvalid_AndOrder(t *testing.T) {
+	w := newBaseWorker("t")
+
+	// ignore non-positive
+	WithBatchSize(0)(w)
+	assert.Equal(t, 1, w.batchSize)
+	WithBatchSize(-5)(w)
+	assert.Equal(t, 1, w.batchSize)
+
+	WithPollInterval(0)(w)
+	assert.Equal(t, 500*time.Millisecond, w.pollInterval)
+	WithPollInterval(-10 * time.Millisecond)(w)
+	assert.Equal(t, 500*time.Millisecond, w.pollInterval)
+
+	// last wins
+	WithBatchSize(3)(w)
+	WithBatchSize(9)(w)
+	assert.Equal(t, 9, w.batchSize)
+
+	WithPollInterval(10 * time.Millisecond)(w)
+	WithPollInterval(25 * time.Millisecond)(w)
+	assert.Equal(t, 25*time.Millisecond, w.pollInterval)
+
+	WithPollTimeout(0)(w)
+	assert.Equal(t, time.Duration(0), w.pollTimeout)
+	WithPollTimeout(-1 * time.Second)(w)
+	assert.Equal(t, -1*time.Second, w.pollTimeout)
+}
+
+func TestWorker_ProviderInterface_ReturnsSelf(t *testing.T) {
+	w := NewWorker("p", func(*model.Task) (interface{}, error) { return nil, nil })
+	var p Provider = w
+	got := p.Worker()
+	assert.Same(t, w, got)
+}
+
+func TestNewWorker_NilHandler_AllowsNilButNotCalled(t *testing.T) {
+	w := NewWorker("nilh", nil)
+	assert.NotNil(t, w)
+	assert.Nil(t, w.handler)
+}

--- a/sdk/worker/worker_typed.go
+++ b/sdk/worker/worker_typed.go
@@ -1,0 +1,77 @@
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+//  the License. You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/conductor-sdk/conductor-go/sdk/model"
+)
+
+// TypedWorker is a compositional typed worker that embeds base configuration via Worker
+// and provides a type-safe function with a WorkflowContext.
+type TypedWorker[TIn, TOut any] struct {
+	base    *Worker
+	handler func(TaskContext, TIn) (TOut, error)
+	binder  InputBinder
+}
+
+// NewSimpleTypedWorker creates a typed worker entity with a simple function.
+func NewSimpleTypedWorker[TIn, TOut any](
+	taskName string,
+	f func(context.Context, TIn) (TOut, error),
+	options ...Option,
+) *TypedWorker[TIn, TOut] {
+	base := newBaseWorker(taskName, options...)
+	adapted := func(ctx TaskContext, in TIn) (TOut, error) {
+		return f(ctx, in)
+	}
+	return &TypedWorker[TIn, TOut]{
+		base:    base,
+		handler: adapted,
+		binder:  JSONBinder{},
+	}
+}
+
+// NewTypedWorker creates a typed worker entity with a TaskContext in the function.
+func NewTypedWorker[TIn, TOut any](
+	taskName string,
+	f func(TaskContext, TIn) (TOut, error),
+	options ...Option,
+) *TypedWorker[TIn, TOut] {
+	base := newBaseWorker(taskName, options...)
+	return &TypedWorker[TIn, TOut]{
+		base:    base,
+		handler: f,
+		binder:  JSONBinder{},
+	}
+}
+
+// adapter returns a legacy ExecuteTaskFunction that invokes the typed handler.
+func (tw *TypedWorker[TIn, TOut]) adapter() model.ExecuteTaskFunction {
+	return func(t *model.Task) (interface{}, error) {
+		// Bind input
+		var in TIn
+		if err := tw.binder.Bind(&in, t.InputData); err != nil {
+			return nil, fmt.Errorf("input binding error for task %s: %w", t.TaskDefName, err)
+		}
+
+		// Execute typed handler
+		return tw.handler(getWorkflowContext(context.Background(), t), in)
+	}
+}
+
+// Worker converts the typed worker into a base Worker.
+func (tw *TypedWorker[TIn, TOut]) Worker() *Worker {
+	w := *tw.base
+	w.handler = tw.adapter()
+	return &w
+}

--- a/sdk/worker/worker_typed_test.go
+++ b/sdk/worker/worker_typed_test.go
@@ -1,0 +1,165 @@
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+//  the License. You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations under the License.
+
+package worker
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/conductor-sdk/conductor-go/sdk/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypedWorker_JSONBinding_Success_DefaultBinder(t *testing.T) {
+	type In struct {
+		A int `json:"a"`
+	}
+	type Out struct {
+		B int `json:"b"`
+	}
+
+	tw := NewTypedWorker(
+		"typed",
+		func(ctx TaskContext, in In) (Out, error) {
+			assert.NotNil(t, ctx)
+			return Out{B: in.A + 10}, nil
+		},
+	)
+
+	res, err := tw.adapter()(&model.Task{
+		TaskDefName: "typed",
+		InputData:   map[string]any{"a": 5},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, Out{B: 15}, res)
+}
+
+func TestTypedWorker_JSONBinding_Error_DefaultBinder(t *testing.T) {
+	type In struct {
+		A int `json:"a"`
+	}
+	type Out struct{}
+
+	tw := NewTypedWorker(
+		"typed_err",
+		func(ctx TaskContext, in In) (Out, error) { return Out{}, nil },
+	)
+
+	_, err := tw.adapter()(&model.Task{
+		TaskDefName: "typed_err",
+		InputData:   map[string]any{"a": "not_an_int"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "input binding error")
+	assert.Contains(t, err.Error(), "typed_err")
+}
+
+func TestTypedWorker_HandlerError_Propagates(t *testing.T) {
+	type In struct {
+		A int `json:"a"`
+	}
+	want := errors.New("handler failed")
+
+	tw := NewTypedWorker("t", func(ctx TaskContext, _ In) (struct{}, error) {
+		return struct{}{}, want
+	})
+
+	_, err := tw.adapter()(&model.Task{
+		TaskDefName: "t",
+		InputData:   map[string]any{"a": 1},
+	})
+
+	assert.ErrorIs(t, err, want)
+}
+
+func TestTypedWorker_Constructors_And_Worker(t *testing.T) {
+	type In struct {
+		A int `json:"a"`
+	}
+	type Out struct {
+		B int `json:"b"`
+	}
+
+	tw := NewTypedWorker("t", func(ctx TaskContext, in In) (Out, error) {
+		return Out{B: in.A}, nil
+	})
+
+	w := tw.Worker()
+	assert.NotNil(t, w)
+	assert.NotSame(t, tw.base, w) // копия, не та же ссылка
+
+	res, err := w.handler(&model.Task{
+		TaskDefName: "t",
+		InputData:   map[string]any{"a": 7},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, Out{B: 7}, res)
+}
+
+func TestTypedWorker_WithTaskContext_Variant(t *testing.T) {
+	type In struct{}
+	type Out struct{}
+
+	seen := false
+	tw := NewTypedWorker("t", func(ctx TaskContext, _ In) (Out, error) {
+		seen = true
+		return Out{}, nil
+	})
+
+	_, err := tw.adapter()(&model.Task{TaskDefName: "t"})
+	assert.NoError(t, err)
+	assert.True(t, seen)
+}
+
+func TestAdapter_TypedNilPointerInOut(t *testing.T) {
+	type In struct {
+		A int `json:"a"`
+	}
+	type Out struct{ X int }
+
+	tw := NewTypedWorker("t", func(ctx TaskContext, in In) (*Out, error) {
+		return nil, nil
+	})
+
+	v, err := tw.adapter()(&model.Task{TaskDefName: "t", InputData: map[string]any{"a": 0}})
+	assert.NoError(t, err)
+	assert.Nil(t, v)
+}
+func TestAdapter_NonNilPointerInOut(t *testing.T) {
+	type In struct {
+		A int `json:"a"`
+	}
+	type Out struct{ X int }
+
+	tw := NewTypedWorker("t", func(ctx TaskContext, in In) (*Out, error) {
+		return &Out{X: 42}, nil
+	})
+
+	v, err := tw.adapter()(&model.Task{TaskDefName: "t", InputData: map[string]any{"a": 1}})
+	assert.NoError(t, err)
+	out, ok := v.(*Out)
+	assert.True(t, ok)
+	assert.Equal(t, 42, out.X)
+}
+func TestAdapter_NilInputData_IsSafe(t *testing.T) {
+	type In struct {
+		A int `json:"a"`
+	}
+	type Out struct {
+		B int `json:"b"`
+	}
+
+	tw := NewTypedWorker("t", func(ctx TaskContext, in In) (Out, error) {
+		return Out{B: in.A + 1}, nil
+	})
+	res, err := tw.adapter()(&model.Task{TaskDefName: "t", InputData: nil})
+	assert.NoError(t, err)
+	assert.Equal(t, Out{B: 1}, res)
+}

--- a/test/integration_tests/worker_typed_test.go
+++ b/test/integration_tests/worker_typed_test.go
@@ -1,0 +1,304 @@
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+//  the License. You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations under the License.
+
+package integration_tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/conductor-sdk/conductor-go/sdk/model"
+	"github.com/conductor-sdk/conductor-go/sdk/worker"
+	"github.com/conductor-sdk/conductor-go/sdk/workflow"
+	"github.com/conductor-sdk/conductor-go/test/testdata"
+)
+
+// uniqueSuffix helps avoid name collisions in CI between parallel runs.
+func uniqueSuffix() string {
+	return fmt.Sprintf("%d", time.Now().UnixNano())
+}
+
+func legacyHandler(tk *model.Task) (interface{}, error) {
+	return map[string]interface{}{
+		"message":   "processed by legacy worker",
+		"taskId":    tk.TaskId,
+		"timestamp": time.Now().Unix(),
+	}, nil
+}
+
+func simpleHandler(ctx context.Context, in interface{}) (interface{}, error) {
+	return map[string]interface{}{
+		"message":   "processed by simple task",
+		"timestamp": time.Now().Unix(),
+	}, nil
+}
+
+func typedHandler(ctx worker.TaskContext, data testdata.TestDataIn) (testdata.TestDataOut, error) {
+	return testdata.TestDataOut{
+		Message: "processed by typed worker",
+		Sum:     data.B + len(data.A),
+		TaskId:  ctx.GetTaskID(),
+	}, nil
+}
+
+// TestLegacyWorkerIntegration validates legacy StartWorker flow with raw map output.
+func TestLegacyWorkerIntegration(t *testing.T) {
+	t.Parallel()
+	suffix := uniqueSuffix()
+	taskName := "TEST_GO_LEGACY_TASK_" + suffix
+	refName := taskName
+
+	wf := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
+		Name("TEST_GO_WF_LEGACY_" + suffix).
+		Version(1).
+		Add(workflow.NewSimpleTask(taskName, refName).Input("test", "test_value")).
+		OutputParameters(map[string]interface{}{
+			"message": fmt.Sprintf("${%s.output.message}", refName),
+		})
+
+	if err := wf.Register(true); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := testdata.TaskRunner.StartWorker(taskName, legacyHandler, 2, testdata.WorkerPollInterval); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]interface{}{"message": "processed by legacy worker"}
+	if err := testdata.ValidateWorkflowWithOutput(wf, testdata.WorkflowValidationTimeout, model.CompletedWorkflow, expected); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRegularWorkerIntegration(t *testing.T) {
+	t.Parallel()
+	suffix := uniqueSuffix()
+	taskName := "TEST_GO_REGULAR_WORKER_" + suffix
+
+	wf := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
+		Name("TEST_GO_WF_REGULAR_" + suffix).
+		Version(1).
+		Add(workflow.NewSimpleTask(taskName, taskName).Input("k", "v")).
+		OutputParameters(map[string]interface{}{
+			"message": fmt.Sprintf("${%s.output.message}", taskName),
+		})
+	if err := wf.Register(true); err != nil {
+		t.Fatal(err)
+	}
+
+	w := worker.NewWorker(
+		taskName,
+		legacyHandler,
+		worker.WithBatchSize(1),
+		worker.WithPollInterval(testdata.WorkerPollInterval),
+	)
+	if err := testdata.TaskRunner.RegisterWorker(w); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]interface{}{"message": "processed by legacy worker"}
+	if err := testdata.ValidateWorkflowWithOutput(wf, testdata.WorkflowValidationTimeout, model.CompletedWorkflow, expected); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestTypedWorkerIntegration validates typed worker with struct input/output.
+func TestTypedWorkerIntegration(t *testing.T) {
+	t.Parallel()
+	suffix := uniqueSuffix()
+	taskName := "TEST_GO_TYPED_TASK_" + suffix
+	refName := taskName
+
+	tw := worker.NewTypedWorker(
+		taskName,
+		typedHandler,
+		worker.WithBatchSize(1),
+		worker.WithPollInterval(testdata.WorkerPollInterval),
+	)
+	if err := testdata.TaskRunner.RegisterWorker(tw); err != nil {
+		t.Fatal(err)
+	}
+
+	task := workflow.NewSimpleTask(taskName, refName).InputMap(map[string]interface{}{"a": "xyz", "b": 10})
+	wf := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
+		Name("TEST_GO_WF_TYPED_" + suffix).
+		Version(1).
+		Add(task).
+		OutputParameters(map[string]interface{}{
+			"message": fmt.Sprintf("${%s.output.message}", refName),
+			"sum":     fmt.Sprintf("${%s.output.sum}", refName),
+		})
+	if err := wf.Register(true); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]interface{}{
+		"message": "processed by typed worker",
+		"sum":     float64(10 + len("xyz")),
+	}
+	if err := testdata.ValidateWorkflowWithOutput(wf, testdata.WorkflowValidationTimeout, model.CompletedWorkflow, expected); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSimpleTypedWorkerIntegration validates typed worker with generic map in/out.
+func TestSimpleTypedWorkerIntegration(t *testing.T) {
+	t.Parallel()
+	suffix := uniqueSuffix()
+	taskName := "TEST_GO_TYPED_MAP_TASK_" + suffix
+	refName := taskName
+
+	tw := worker.NewSimpleTypedWorker(
+		taskName,
+		simpleHandler,
+		worker.WithBatchSize(2),
+		worker.WithPollInterval(testdata.WorkerPollInterval),
+	)
+	if err := testdata.TaskRunner.RegisterWorker(tw); err != nil {
+		t.Fatal(err)
+	}
+
+	task := workflow.NewSimpleTask(taskName, refName).InputMap(map[string]interface{}{"foo": "bar", "k": 5})
+	wf := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
+		Name("TEST_GO_WF_TYPED_MAP_" + suffix).
+		Version(1).
+		Add(task).
+		OutputParameters(map[string]interface{}{
+			"message": fmt.Sprintf("${%s.output.message}", refName),
+		})
+	if err := wf.Register(true); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]interface{}{"message": "processed by simple task"}
+	if err := testdata.ValidateWorkflowWithOutput(wf, testdata.WorkflowValidationTimeout, model.CompletedWorkflow, expected); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestMultiTaskWorkflowIntegration validates a sequence of mixed legacy and typed workers.
+func TestMultiTaskWorkflowIntegration(t *testing.T) {
+	t.Parallel()
+	suffix := uniqueSuffix()
+	t.Logf("Starting TestMultiTaskWorkflowIntegration with suffix: %s", suffix)
+
+	// Tasks
+	legacyTaskName := "TEST_GO_LEG_MULTI_" + suffix
+	regularTaskName := "TEST_GO_REG_MULTI_" + suffix
+	typedTaskName := "TEST_GO_TYP_MULTI_" + suffix
+	typedSimpleName := "TEST_GO_TYP_SIMPLE_MULTI_" + suffix
+
+	// Start legacy worker
+	if err := testdata.TaskRunner.StartWorker(legacyTaskName, legacyHandler, 1, testdata.WorkerPollInterval); err != nil {
+		t.Fatal(err)
+	}
+
+	typedWorker := worker.NewTypedWorker(
+		typedTaskName,
+		typedHandler,
+		worker.WithBatchSize(1),
+		worker.WithPollInterval(testdata.WorkerPollInterval),
+	)
+
+	if err := testdata.TaskRunner.RegisterWorker(typedWorker); err != nil {
+		t.Fatal(err)
+	}
+
+	typedWithCtxWorker := worker.NewSimpleTypedWorker(
+		typedSimpleName,
+		simpleHandler,
+		worker.WithBatchSize(1),
+		worker.WithPollInterval(testdata.WorkerPollInterval),
+	)
+
+	if err := testdata.TaskRunner.RegisterWorker(typedWithCtxWorker); err != nil {
+		t.Fatal(err)
+	}
+
+	regularWorker := worker.NewWorker(
+		regularTaskName,
+		legacyHandler,
+		worker.WithBatchSize(1),
+		worker.WithPollInterval(testdata.WorkerPollInterval),
+	)
+
+	if err := testdata.TaskRunner.RegisterWorker(regularWorker); err != nil {
+		t.Fatal(err)
+	}
+
+	wf := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
+		Name("TEST_GO_WF_MULTI_" + suffix).
+		Version(1).
+		Add(workflow.NewSimpleTask(legacyTaskName, legacyTaskName).
+			Input("test", "test_value")).
+		Add(workflow.NewSimpleTask(typedTaskName, typedTaskName).
+			InputMap(map[string]interface{}{"a": "xyz", "b": 10})).
+		Add(workflow.NewSimpleTask(typedSimpleName, typedSimpleName).
+			InputMap(map[string]interface{}{"foo": "bar", "k": 5})).
+		Add(workflow.NewSimpleTask(regularTaskName, regularTaskName).
+			InputMap(map[string]interface{}{"test": "test_value"}))
+
+	if err := wf.Register(true); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := testdata.ValidateWorkflow(wf, testdata.ExtendedValidationTimeout, model.CompletedWorkflow); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestParallelExecutionIntegration validates fork-join with two typed workers.
+func TestParallelExecutionIntegration(t *testing.T) {
+	t.Parallel()
+	suffix := uniqueSuffix()
+	taskName := "TEST_GO_PARALLEL_" + suffix
+	taskName1 := fmt.Sprintf("%s_1", taskName)
+	taskName2 := fmt.Sprintf("%s_2", taskName)
+	taskName3 := fmt.Sprintf("%s_3", taskName)
+	taskName4 := fmt.Sprintf("%s_4", taskName)
+
+	// Workers
+	wA := worker.NewTypedWorker(
+		taskName,
+		typedHandler,
+		worker.WithBatchSize(4),
+		worker.WithPollInterval(testdata.WorkerPollInterval),
+	)
+
+	if err := testdata.TaskRunner.RegisterWorker(wA); err != nil {
+		t.Fatal(err)
+	}
+
+	w := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
+		Name("TEST_GO_WF_PARALLEL_" + suffix).
+		Version(1)
+
+	fork := workflow.NewForkTask("parallel_fork_"+suffix,
+		[]workflow.TaskInterface{
+			workflow.NewSimpleTask(taskName, taskName1).InputMap(map[string]interface{}{"a": "xyz", "b": 10}),
+			workflow.NewSimpleTask(taskName, taskName2).InputMap(map[string]interface{}{"a": "xyz", "b": 5}),
+		},
+		[]workflow.TaskInterface{
+			workflow.NewSimpleTask(taskName, taskName3).InputMap(map[string]interface{}{"a": "xyz", "b": 5}),
+			workflow.NewSimpleTask(taskName, taskName4).InputMap(map[string]interface{}{"a": "xyz", "b": 10}),
+		},
+	)
+	w.Add(fork).Add(workflow.NewJoinTask("join_ref", taskName1, taskName2, taskName3, taskName4))
+
+	if err := w.Register(true); err != nil {
+		t.Fatal(err)
+	}
+
+	// No explicit output assertion here; validate completion only
+	if err := testdata.ValidateWorkflow(w, testdata.WorkflowValidationTimeout, model.CompletedWorkflow); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/testdata/kitchensink.go
+++ b/test/testdata/kitchensink.go
@@ -115,7 +115,6 @@ type WorkflowTask struct {
 }
 
 func DynamicForkWorker(t *model.Task) (output interface{}, err error) {
-	taskResult := model.NewTaskResultFromTask(t)
 	tasks := []WorkflowTask{
 		{
 			Name:              "simple_task",
@@ -148,13 +147,10 @@ func DynamicForkWorker(t *model.Task) (output interface{}, err error) {
 		},
 	}
 
-	taskResult.OutputData = map[string]interface{}{
+	return map[string]interface{}{
 		"forkedTasks":       tasks,
 		"forkedTasksInputs": inputs,
-	}
-	taskResult.Status = model.CompletedTask
-	err = nil
-	return taskResult, err
+	}, nil
 }
 
 func GetWorkflowWithComplexSwitchTask() *workflow.ConductorWorkflow {

--- a/test/testdata/typed_workers.go
+++ b/test/testdata/typed_workers.go
@@ -1,0 +1,23 @@
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+//  the License. You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations under the License.
+
+package testdata
+
+// TestDataIn represents a simple typed input payload for typed workers.
+type TestDataIn struct {
+	A string `json:"a"`
+	B int    `json:"b"`
+}
+
+// TestDataOut represents a simple typed output payload for typed workers.
+type TestDataOut struct {
+	Message string `json:"message"`
+	Sum     int    `json:"sum"`
+	TaskId  string `json:"taskId"`
+}


### PR DESCRIPTION
### Summary
Adds a new, type-safe Worker API with generics and contextual execution, plus unit and integration tests. Keeps legacy behavior intact while enabling clearer configuration and registration. Golang version is 1.23

### Motivation
- Provide type-safe handlers with structured input/output.
- Expose execution context (workflow/task metadata) to handlers.
- Unify registration via provider pattern and options while remaining backward compatible.

### What’s in this PR
- New worker module:
  - `Worker` with options: `WithBatchSize`, `WithPollInterval`, `WithPollTimeout`, `WithDomain`
  - `TypedWorker[TIn, TOut]` for generic, type-safe handlers
  - `TaskContext` exposing workflow/task metadata
  - `InputBinder` and `JSONBinder` for binding inputs to typed structs
  - `Provider` interface for `Worker`/`TypedWorker` adaptation
- Task runner integration:
  - `RegisterWorker`/`RegisterWorkers` accept any `Provider`, apply per-task poll interval/timeout, and start/scale workers
  - Existing batch/concurrency semantics preserved
- Tests:
  - Unit tests for options and worker behavior
  - Integration tests for legacy, regular, and typed workers (including parallel/fork-join)
- CI/build:
  - Updated GitHub workflows, `Dockerfile`, and `go.mod`

### Backward compatibility
- No breaking changes
- Existing `StartWorker` flow remains unchanged
- Recommended: prefer `Worker`/`TypedWorker` + `RegisterWorker` for clearer configuration and scaling

### Testing
- Unit and integration coverage for legacy and typed workers, including parallel execution and end-to-end workflow validation