### PR TITLE
fix: return struct instead of interface in logger factory

### DIFF
--- a/sdk/log/std.go
+++ b/sdk/log/std.go
@@ -13,19 +13,19 @@ type stdLogger struct {
 }
 
 const (
-	lvlDebug = iota
-	lvlInfo
-	lvlWarn
-	lvlError
+	LvlDebug = iota
+	LvlInfo
+	LvlWarn
+	LvlError
 )
 
 func levelStr(l int) string {
 	switch l {
-	case lvlDebug:
+	case LvlDebug:
 		return "[DEBUG]"
-	case lvlInfo:
+	case LvlInfo:
 		return "[INFO]"
-	case lvlWarn:
+	case LvlWarn:
 		return "[WARN]"
 	default:
 		return "[ERROR]"
@@ -69,10 +69,10 @@ func (s *stdLogger) logf(lvl int, args ...interface{}) {
 	s.l.Printf("%s %s", levelStr(lvl), formatArgs(args...))
 }
 
-func (s *stdLogger) Debug(a ...interface{}) { s.logf(lvlDebug, a...) }
-func (s *stdLogger) Info(a ...interface{})  { s.logf(lvlInfo, a...) }
-func (s *stdLogger) Warn(a ...interface{})  { s.logf(lvlWarn, a...) }
-func (s *stdLogger) Error(a ...interface{}) { s.logf(lvlError, a...) }
+func (s *stdLogger) Debug(a ...interface{}) { s.logf(LvlDebug, a...) }
+func (s *stdLogger) Info(a ...interface{})  { s.logf(LvlInfo, a...) }
+func (s *stdLogger) Warn(a ...interface{})  { s.logf(LvlWarn, a...) }
+func (s *stdLogger) Error(a ...interface{}) { s.logf(LvlError, a...) }
 
 func (s *stdLogger) Fatal(a ...interface{}) {
 	s.l.Fatal(formatArgs(a...))
@@ -106,7 +106,7 @@ func (s *stdLogger) With(vals ...interface{}) Logger {
 }
 
 // NewStd creates a new Logger that wraps a log.Logger.
-func NewStd(l *log.Logger) Logger {
+func NewStd(l *log.Logger) *stdLogger {
 	if l == nil {
 		l = log.New(os.Stdout, "", log.LstdFlags)
 	}

--- a/sdk/log/std_test.go
+++ b/sdk/log/std_test.go
@@ -30,18 +30,18 @@ func TestStd_LevelsAndFilter(t *testing.T) {
 		expectPrint bool
 		wantPrefix  string
 	}{
-		{"Debug_pass", func(l Logger) { l.Debug("d") }, lvlDebug, true, "[DEBUG]"},
-		{"Debug_filtered", func(l Logger) { l.Debug("d") }, lvlInfo, false, ""},
-		{"Info_pass", func(l Logger) { l.Info("i") }, lvlInfo, true, "[INFO]"},
-		{"Warn_pass", func(l Logger) { l.Warn("w") }, lvlInfo, true, "[WARN]"},
-		{"Error_pass", func(l Logger) { l.Error("e") }, lvlInfo, true, "[ERROR]"},
+		{"Debug_pass", func(l Logger) { l.Debug("d") }, LvlDebug, true, "[DEBUG]"},
+		{"Debug_filtered", func(l Logger) { l.Debug("d") }, LvlInfo, false, ""},
+		{"Info_pass", func(l Logger) { l.Info("i") }, LvlInfo, true, "[INFO]"},
+		{"Warn_pass", func(l Logger) { l.Warn("w") }, LvlInfo, true, "[WARN]"},
+		{"Error_pass", func(l Logger) { l.Error("e") }, LvlInfo, true, "[ERROR]"},
 	}
 
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			buf, goStd := capture()
-			l := NewStd(goStd).(*stdLogger)
+			l := NewStd(goStd)
 			l.SetLevel(tc.setLevel)
 
 			tc.logFn(l)

--- a/sdk/log/zap.go
+++ b/sdk/log/zap.go
@@ -12,7 +12,7 @@ type ZapLogger struct {
 }
 
 // NewZap creates a new ZapLogger that wraps a zap.Logger.
-func NewZap(l *zap.Logger) Logger {
+func NewZap(l *zap.Logger) *ZapLogger {
 	return &ZapLogger{l: l}
 }
 


### PR DESCRIPTION
## Summary

1. Use pointer to struct instead of interface in logger factory
2. Uppercase name for exported const