### PR TITLE
feat: split tests by cluster version

### DIFF
--- a/sdk/client/api_version_resource.go
+++ b/sdk/client/api_version_resource.go
@@ -1,0 +1,37 @@
+// Package client provides API client functionality for Conductor
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+package client
+
+import (
+	"context"
+	"net/http"
+)
+
+// VersionResourceAPIService is a service for getting the server's version
+type VersionResourceAPIService struct {
+	*APIClient
+}
+
+// NewVersionResourceAPIService creates a new VersionResourceAPIService
+func NewVersionResourceAPIService(apiClient *APIClient) *VersionResourceAPIService {
+	return &VersionResourceAPIService{APIClient: apiClient}
+}
+
+// GetVersion gets the server's version
+func (a *VersionResourceAPIService) GetVersion(ctx context.Context) (string, *http.Response, error) {
+	var result string
+	path := "/version"
+	resp, err := a.Get(ctx, path, nil, &result)
+	if err != nil {
+		return "", resp, err
+	}
+	return result, resp, nil
+}

--- a/sdk/client/version_resource_client.go
+++ b/sdk/client/version_resource_client.go
@@ -1,0 +1,26 @@
+// Package client provides API client functionality for Conductor
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+package client
+
+import (
+	"context"
+	"net/http"
+)
+
+// VersionResourceClient provides methods for accessing version information
+type VersionResourceClient interface {
+	GetVersion(ctx context.Context) (string, *http.Response, error)
+}
+
+// NewVersionResourceClient creates a new VersionResourceClient instance
+func NewVersionResourceClient(client *APIClient) VersionResourceClient {
+	return NewVersionResourceAPIService(client)
+}

--- a/test/integration_tests/application_client_test.go
+++ b/test/integration_tests/application_client_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestApplicationLifecycle(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
 
 	appClient := testdata.ApplicationClient
 
@@ -40,6 +41,7 @@ func TestApplicationLifecycle(t *testing.T) {
 }
 
 func TestRoleManagementForApplicationUser(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
 
 	appClient := testdata.ApplicationClient
 
@@ -63,6 +65,8 @@ func TestRoleManagementForApplicationUser(t *testing.T) {
 }
 
 func TestAuthorizationResourcePermissions(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	// Setup
 	appClient := testdata.ApplicationClient
 	authClient := testdata.AuthorizationClient
@@ -122,6 +126,8 @@ func TestAuthorizationResourcePermissions(t *testing.T) {
 }
 
 func TestAccessKeyLifecycle(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	appClient := testdata.ApplicationClient
 
 	// Create an application to use in the test
@@ -144,6 +150,7 @@ func TestAccessKeyLifecycle(t *testing.T) {
 }
 
 func TestGetTagsForApplication(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
 
 	appClient := testdata.ApplicationClient
 
@@ -166,6 +173,8 @@ func TestGetTagsForApplication(t *testing.T) {
 }
 
 func TestApplicationClientIntegration(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	// Initialize ApplicationClient
 	appClient := testdata.ApplicationClient
 
@@ -225,6 +234,8 @@ func TestApplicationClientIntegration(t *testing.T) {
 }
 
 func TestApplicationClientErrorHandling(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	// Initialize ApplicationClient
 	appClient := testdata.ApplicationClient
 
@@ -277,6 +288,8 @@ func TestApplicationClientErrorHandling(t *testing.T) {
 }
 
 func TestGetAccessKeys(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	// Initialize ApplicationClient
 	appClient := testdata.ApplicationClient
 

--- a/test/integration_tests/env_client_test.go
+++ b/test/integration_tests/env_client_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestCreateOrUpdateEnvVariable(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	ctx := context.Background()
 	envClient := NewEnvironmentClient()
 
@@ -26,6 +28,8 @@ func TestCreateOrUpdateEnvVariable(t *testing.T) {
 }
 
 func TestDeleteEnvVariable(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	TestCreateOrUpdateEnvVariable(t)
 	ctx := context.Background()
 	envClient := NewEnvironmentClient()
@@ -38,6 +42,8 @@ func TestDeleteEnvVariable(t *testing.T) {
 }
 
 func TestDeleteTagForEnvVar(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	TestCreateOrUpdateEnvVariable(t)
 	ctx := context.Background()
 	envClient := NewEnvironmentClient()
@@ -51,6 +57,8 @@ func TestDeleteTagForEnvVar(t *testing.T) {
 }
 
 func TestGetEnvVariable(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	ctx := context.Background()
 	envClient := NewEnvironmentClient()
 
@@ -62,6 +70,8 @@ func TestGetEnvVariable(t *testing.T) {
 }
 
 func TestGetAllEnvVariables(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	TestCreateOrUpdateEnvVariable(t)
 	ctx := context.Background()
 	envClient := NewEnvironmentClient()
@@ -73,6 +83,8 @@ func TestGetAllEnvVariables(t *testing.T) {
 }
 
 func TestGetTagsForEnvVar(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	TestUpsertUser(t)
 	ctx := context.Background()
 	envClient := NewEnvironmentClient()
@@ -86,6 +98,8 @@ func TestGetTagsForEnvVar(t *testing.T) {
 }
 
 func TestPutTagForEnvVar(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	ctx := context.Background()
 	envClient := NewEnvironmentClient()
 	tags := []model.Tag{{Key: "tag1", Value: "value1"}}

--- a/test/integration_tests/executor_test.go
+++ b/test/integration_tests/executor_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/conductor-sdk/conductor-go/sdk/workflow"
 	"github.com/conductor-sdk/conductor-go/test/testdata"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -26,6 +27,8 @@ const (
 )
 
 func TestRetryNotFound(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 
 	err := executor.Retry(notFoundWorkflowId, true)
@@ -39,6 +42,8 @@ func TestRetryNotFound(t *testing.T) {
 }
 
 func TestRegisterWorkflow(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 
 	wf := workflow.ConductorWorkflow{}
@@ -68,6 +73,8 @@ func TestRegisterWorkflow(t *testing.T) {
 }
 
 func TestRegisterWorkflowWithTags(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 
 	wf := workflow.NewConductorWorkflow(executor)
@@ -140,6 +147,8 @@ func TestRegisterWorkflowWithTags(t *testing.T) {
 }
 
 func TestGetWorkflow(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 
 	wf, err := executor.GetWorkflow(notFoundWorkflowId, false)
@@ -150,6 +159,8 @@ func TestGetWorkflow(t *testing.T) {
 }
 
 func TestUpdateTaskByRefName(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 	err := executor.UpdateTaskByRefName("task_ref", notFoundWorkflowId, model.CompletedTask, map[string]interface{}{})
 	assert.Error(t, err, "UpdateTaskByRefName is expected to return an error")
@@ -161,6 +172,8 @@ func TestUpdateTaskByRefName(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 	err := executor.UpdateTask(notFoundTaskId, notFoundWorkflowId, model.CompletedTask, map[string]interface{}{})
 	assert.Error(t, err, "UpdateTask is expected to return an error")
@@ -172,6 +185,8 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestStartWorkflowWithContext(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -224,6 +239,8 @@ func getSubWorkflow(t *testing.T) workflow.ConductorWorkflow {
 }
 
 func TestRegisterWorkflowWithWaitSignal(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV52)
+
 	executor := testdata.WorkflowExecutor
 	wf := getSubWorkflow(t)
 
@@ -261,6 +278,8 @@ func TestRegisterWorkflowWithWaitSignal(t *testing.T) {
 }
 
 func TestSubWorkflowSignal(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV52)
+
 	executor := testdata.WorkflowExecutor
 
 	subWf := getSubWorkflow(t)
@@ -349,6 +368,8 @@ func waitForWorkflowCompletion(executor *executor.WorkflowExecutor, workflowId s
 }
 
 func TestSubWorkflowSignalWithSyncConsistency(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV52)
+
 	executor := testdata.WorkflowExecutor
 
 	// First, make sure the wait_signal_test workflow is registered
@@ -369,7 +390,8 @@ func TestSubWorkflowSignalWithSyncConsistency(t *testing.T) {
 		[]string{""},
 		10,
 	)
-	assert.NotNil(t, workflowRun)
+	require.NoError(t, err)
+	require.NotNil(t, workflowRun)
 
 	parentWorkflowId := workflowRun.WorkflowId
 
@@ -413,6 +435,8 @@ func TestSubWorkflowSignalWithSyncConsistency(t *testing.T) {
 }
 
 func TestSubWorkflowSignalWithDurableConsistency(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV52)
+
 	executor := testdata.WorkflowExecutor
 
 	// Create the workflow start request
@@ -430,7 +454,8 @@ func TestSubWorkflowSignalWithDurableConsistency(t *testing.T) {
 		[]string{""},
 		10,
 	)
-	assert.NotNil(t, workflowRun)
+	require.NoError(t, err)
+	require.NotNil(t, workflowRun)
 
 	parentWorkflowId := workflowRun.WorkflowId
 
@@ -524,6 +549,8 @@ func getWorkflowDef(filename string) (*model.WorkflowDef, error) {
 }
 
 func TestSignal_AllStrategies_Comprehensive(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV52)
+
 	registerComplexWorkflows()
 	testCases := []struct {
 		name                         string
@@ -673,8 +700,8 @@ func TestSignal_AllStrategies_Comprehensive(t *testing.T) {
 				10,
 			)
 
-			assert.Nil(t, err)
-			assert.NotEmpty(t, resp)
+			require.Nil(t, err)
+			require.NotEmpty(t, resp)
 			workflowId := resp.WorkflowId
 
 			t.Logf("Started complex workflow with ID: %s for strategy: %s, Consistency: %s", workflowId, tc.name, tc.consistency.String())
@@ -830,6 +857,8 @@ func TestSignal_AllStrategies_Comprehensive(t *testing.T) {
 
 // Add a separate test for default strategy to ensure it behaves like TARGET_WORKFLOW
 func TestSignal_DefaultStrategy_IsTargetWorkflow(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV52)
+
 	// Setup workflow (same setup code as in your original test)
 	executor := testdata.WorkflowExecutor
 	registerComplexWorkflows()
@@ -847,7 +876,8 @@ func TestSignal_DefaultStrategy_IsTargetWorkflow(t *testing.T) {
 		[]string{""},
 		10,
 	)
-	assert.Nil(t, err)
+	require.Nil(t, err)
+	require.NotNil(t, workflowRun)
 	workflowId := workflowRun.WorkflowId
 
 	time.Sleep(20 * time.Millisecond)
@@ -881,6 +911,8 @@ func TestSignal_DefaultStrategy_IsTargetWorkflow(t *testing.T) {
 
 // Add a separate test for mixed strategy
 func TestSignal_MixedStrategy(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV52)
+
 	// Setup workflow (same setup code as in your original test)
 	executor := testdata.WorkflowExecutor
 	registerComplexWorkflows()
@@ -898,7 +930,8 @@ func TestSignal_MixedStrategy(t *testing.T) {
 		[]string{""},
 		10,
 	)
-	assert.Nil(t, err)
+	require.Nil(t, err)
+	require.NotNil(t, workflowRun)
 	workflowId := workflowRun.WorkflowId
 
 	time.Sleep(20 * time.Millisecond)
@@ -911,8 +944,8 @@ func TestSignal_MixedStrategy(t *testing.T) {
 		})
 
 	// Should behave exactly like TARGET_WORKFLOW
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
 	assert.Equal(t, model.ReturnBlockingWorkflow, resp.ResponseType, "Default strategy should be BLOCKING_WORKFLOW")
 	assert.True(t, resp.IsBlockingWorkflow(), "Default should behave like BLOCKING_WORKFLOW")
 
@@ -936,6 +969,8 @@ func TestSignal_MixedStrategy(t *testing.T) {
 }
 
 func TestWfExecutionWithWaitForSec_Success(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV52)
+
 	executor := testdata.WorkflowExecutor
 
 	wf := workflow.ConductorWorkflow{}
@@ -970,6 +1005,8 @@ func TestWfExecutionWithWaitForSec_Success(t *testing.T) {
 }
 
 func TestWfExecutionWithWaitForSec_ContextTimeout(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	wfClient := testdata.WorkflowClient
 	executor := testdata.WorkflowExecutor
 	// Create a very short context timeout

--- a/test/integration_tests/group_client_test.go
+++ b/test/integration_tests/group_client_test.go
@@ -3,14 +3,17 @@ package integration_tests
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/conductor-sdk/conductor-go/sdk/model/rbac"
 	"github.com/conductor-sdk/conductor-go/test/testdata"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestGroupResourceApiService(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	// Setup
 	groupClient := testdata.GroupClient // Assuming this exists in your testdata package
 

--- a/test/integration_tests/integration_client_test.go
+++ b/test/integration_tests/integration_client_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestIntegrationClient(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	ctx := context.Background()
 
 	// Instantiate the IntegrationClient
@@ -170,14 +172,12 @@ func TestIntegrationClient(t *testing.T) {
 	for _, integration := range integrations {
 		require.NotNil(t, integration)
 		require.True(t, integration.Enabled)
-		require.Equal(t, "AI_MODEL", integration.Category)
+		require.NotEmpty(t, integration.Category)
 	}
 
-	integrationDefs, resp, err := testdata.IntegrationClient.GetIntegrationProviderDefs(ctx)
+	_, resp, err = testdata.IntegrationClient.GetIntegrationProviderDefs(ctx)
 	require.NoError(t, err, "Failed to retrieve integration providers")
 	require.NotNil(t, resp, "Response should not be nil")
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.Equal(t, 29, len(integrationDefs))
 
 	promptClient.DeleteMessageTemplate(ctx, promptName)
 	template, res, err := promptClient.GetMessageTemplate(ctx, promptName)

--- a/test/integration_tests/metadata_resource_test.go
+++ b/test/integration_tests/metadata_resource_test.go
@@ -22,6 +22,8 @@ const WorkflowName = "TestGoSDKWorkflowWithTags"
 const TaskName = "TEST_GO_SIMPLE_TASK"
 
 func TestRegisterWorkflowDef(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	ctx := context.Background()
 	_, _ = testdata.MetadataClient.UnregisterWorkflowDef(ctx, WorkflowName, 1)
 	task := model.WorkflowTask{
@@ -56,7 +58,7 @@ func TestRegisterWorkflowDef(t *testing.T) {
 }
 
 func TestRegisterWorkflowDefWithTags(t *testing.T) {
-
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
 	_, _ = testdata.MetadataClient.UnregisterWorkflowDef(context.Background(), WorkflowName, 1)
 	task := model.WorkflowTask{
 		Name:              "simple_task",
@@ -113,6 +115,7 @@ func TestRegisterWorkflowDefWithTags(t *testing.T) {
 }
 
 func TestUpdateWorkflowDefWithTags(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
 
 	_, _ = testdata.MetadataClient.UnregisterWorkflowDef(context.Background(), WorkflowName, 1)
 
@@ -184,6 +187,8 @@ func TestUpdateWorkflowDefWithTags(t *testing.T) {
 }
 
 func TestRegisterTaskDefWithTags(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	taskDef := model.TaskDef{
 		Name:        TaskName,
 		Description: "Test task definition created from Go SDK",
@@ -211,6 +216,8 @@ func TestRegisterTaskDefWithTags(t *testing.T) {
 }
 
 func TestGetTagsForTaskDef(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	tags, err := testdata.MetadataClient.GetTagsForTaskDef(context.Background(), TaskName)
 
 	if err == nil {
@@ -223,6 +230,8 @@ func TestGetTagsForTaskDef(t *testing.T) {
 }
 
 func TestUpdateTaskDefWithTags(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	taskDef := model.TaskDef{
 		Name:        TaskName,
 		Description: "Test task definition updated from Go SDK",

--- a/test/integration_tests/scheduler_client_test.go
+++ b/test/integration_tests/scheduler_client_test.go
@@ -3,16 +3,18 @@ package integration_tests
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/antihax/optional"
 	"github.com/conductor-sdk/conductor-go/sdk/client"
 	"github.com/conductor-sdk/conductor-go/sdk/model"
 	"github.com/conductor-sdk/conductor-go/test/testdata"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestSchedulerResourceApiService(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
 	// Setup
 	const WorkflowName = "TestGoSDKWorkflowForSchedulerClient"
 	schedulerClient := testdata.SchedulerClient // Assuming this exists in your testdata package

--- a/test/integration_tests/secret_client_test.go
+++ b/test/integration_tests/secret_client_test.go
@@ -3,14 +3,17 @@ package integration_tests
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/conductor-sdk/conductor-go/sdk/model"
 	"github.com/conductor-sdk/conductor-go/test/testdata"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestSecretResourceApiService(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	// Setup
 	secretClient := testdata.SecretClient // Assuming this exists in your testdata package
 	ctx := context.Background()

--- a/test/integration_tests/service_registry_client_test.go
+++ b/test/integration_tests/service_registry_client_test.go
@@ -2,14 +2,15 @@ package integration_tests
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/antihax/optional"
 	"github.com/conductor-sdk/conductor-go/sdk/client"
 	"github.com/conductor-sdk/conductor-go/sdk/model"
 	"github.com/conductor-sdk/conductor-go/test/testdata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 const (
@@ -45,6 +46,8 @@ func (s *ServiceRegistryClientTestSuite) cleanup(t *testing.T) {
 }
 
 func TestServiceRegistryClient_HTTPService(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV52)
+
 	suite := setupServiceRegistryTest(t)
 	defer suite.cleanup(t)
 
@@ -138,6 +141,8 @@ func TestServiceRegistryClient_HTTPService(t *testing.T) {
 }
 
 func TestServiceRegistryClient_GRPCService(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV52)
+
 	suite := setupServiceRegistryTest(t)
 	defer suite.cleanup(t)
 
@@ -234,6 +239,8 @@ func TestServiceRegistryClient_GRPCService(t *testing.T) {
 }
 
 func TestServiceRegistryClient_CircuitBreaker(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV52)
+
 	suite := setupServiceRegistryTest(t)
 	defer suite.cleanup(t)
 
@@ -272,6 +279,8 @@ func TestServiceRegistryClient_CircuitBreaker(t *testing.T) {
 }
 
 func TestServiceRegistryClient_MethodOperations(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV52)
+
 	suite := setupServiceRegistryTest(t)
 	defer suite.cleanup(t)
 

--- a/test/integration_tests/task_resource_test.go
+++ b/test/integration_tests/task_resource_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestUpdateTaskRefByName(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	simpleTaskWorkflow := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
 		Name("TEST_GO_WORKFLOW_UPDATE_TASK").
 		Version(1).

--- a/test/integration_tests/user_client_test.go
+++ b/test/integration_tests/user_client_test.go
@@ -14,6 +14,8 @@ import (
 
 // TestCheckPermissions checks if permissions for a user can be retrieved correctly.
 func TestCheckPermissions(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	TestUpsertUser(t)
 	client := NewUserClient()
 	ctx := context.Background()
@@ -35,6 +37,8 @@ func TestCheckPermissions(t *testing.T) {
 
 // TestDeleteUser verifies that a user can be successfully deleted.
 func TestDeleteUser(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	TestUpsertUser(t)
 	client := NewUserClient()
 	ctx := context.Background()
@@ -51,6 +55,8 @@ func TestDeleteUser(t *testing.T) {
 
 // TestGetGrantedPermissions checks if granted permissions can be fetched for a user.
 func TestGetGrantedPermissions(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	TestUpsertUser(t)
 	client := NewUserClient()
 	ctx := context.Background()
@@ -70,6 +76,8 @@ func TestGetGrantedPermissions(t *testing.T) {
 
 // TestGetUser checks fetching a specific user's details.
 func TestGetUser(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	TestUpsertUser(t)
 	client := NewUserClient()
 	ctx := context.Background()
@@ -88,6 +96,8 @@ func TestGetUser(t *testing.T) {
 }
 
 func TestGetUserNotFound(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	TestUpsertUser(t)
 	client := NewUserClient()
 	ctx := context.Background()
@@ -104,6 +114,8 @@ func TestGetUserNotFound(t *testing.T) {
 
 // TestListUsers checks listing users with optional parameters.
 func TestListUsers(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	user_client := NewUserClient()
 	ctx := context.Background()
 	options := client.UserResourceApiListUsersOpts{Apps: optional.NewBool(true)}
@@ -122,6 +134,8 @@ func TestListUsers(t *testing.T) {
 
 // TestUpsertUser verifies that a user can be updated or inserted.
 func TestUpsertUser(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	client := NewUserClient()
 	ctx := context.Background()
 	body := rbac.UpsertUserRequest{

--- a/test/integration_tests/webhook_client_test.go
+++ b/test/integration_tests/webhook_client_test.go
@@ -3,14 +3,17 @@ package integration_tests
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/conductor-sdk/conductor-go/sdk/model"
 	"github.com/conductor-sdk/conductor-go/test/testdata"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestWebhooksConfigResourceApiService(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	// Setup
 	webhookClient := testdata.WebhookClient // Assuming this exists in your testdata package
 	ctx := context.Background()

--- a/test/integration_tests/worker_test.go
+++ b/test/integration_tests/worker_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestWorkerBatchSize(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	simpleTaskWorkflow := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
 		Name("TEST_GO_WORKFLOW_SIMPLE").
 		Version(1).
@@ -69,6 +71,8 @@ func TestWorkerBatchSize(t *testing.T) {
 }
 
 func TestFaultyWorker(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	taskName := "TEST_GO_FAULTY_TASK"
 	wf := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
 		Name("TEST_GO_FAULTY_WORKFLOW").
@@ -94,6 +98,8 @@ func TestFaultyWorker(t *testing.T) {
 }
 
 func TestWorkerWithNonRetryableError(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	taskName := "TEST_GO_NON_RETRYABLE_ERROR_TASK"
 	wf := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
 		Name("TEST_GO_NON_RETRYABLE_ERROR_WF").

--- a/test/integration_tests/worker_typed_test.go
+++ b/test/integration_tests/worker_typed_test.go
@@ -51,6 +51,8 @@ func typedHandler(ctx worker.TaskContext, data testdata.TestDataIn) (testdata.Te
 
 // TestLegacyWorkerIntegration validates legacy StartWorker flow with raw map output.
 func TestLegacyWorkerIntegration(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	t.Parallel()
 	suffix := uniqueSuffix()
 	taskName := "TEST_GO_LEGACY_TASK_" + suffix
@@ -79,6 +81,8 @@ func TestLegacyWorkerIntegration(t *testing.T) {
 }
 
 func TestRegularWorkerIntegration(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	t.Parallel()
 	suffix := uniqueSuffix()
 	taskName := "TEST_GO_REGULAR_WORKER_" + suffix
@@ -112,6 +116,8 @@ func TestRegularWorkerIntegration(t *testing.T) {
 
 // TestTypedWorkerIntegration validates typed worker with struct input/output.
 func TestTypedWorkerIntegration(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	t.Parallel()
 	suffix := uniqueSuffix()
 	taskName := "TEST_GO_TYPED_TASK_" + suffix
@@ -151,6 +157,8 @@ func TestTypedWorkerIntegration(t *testing.T) {
 
 // TestSimpleTypedWorkerIntegration validates typed worker with generic map in/out.
 func TestSimpleTypedWorkerIntegration(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	t.Parallel()
 	suffix := uniqueSuffix()
 	taskName := "TEST_GO_TYPED_MAP_TASK_" + suffix
@@ -186,6 +194,8 @@ func TestSimpleTypedWorkerIntegration(t *testing.T) {
 
 // TestMultiTaskWorkflowIntegration validates a sequence of mixed legacy and typed workers.
 func TestMultiTaskWorkflowIntegration(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	t.Parallel()
 	suffix := uniqueSuffix()
 	t.Logf("Starting TestMultiTaskWorkflowIntegration with suffix: %s", suffix)
@@ -257,6 +267,8 @@ func TestMultiTaskWorkflowIntegration(t *testing.T) {
 
 // TestParallelExecutionIntegration validates fork-join with two typed workers.
 func TestParallelExecutionIntegration(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	t.Parallel()
 	suffix := uniqueSuffix()
 	taskName := "TEST_GO_PARALLEL_" + suffix

--- a/test/integration_tests/workflow_client_test.go
+++ b/test/integration_tests/workflow_client_test.go
@@ -2,16 +2,19 @@ package integration_tests
 
 import (
 	"context"
+	"net/http"
+	"testing"
+
 	"github.com/antihax/optional"
 	"github.com/conductor-sdk/conductor-go/sdk/client"
 	"github.com/conductor-sdk/conductor-go/sdk/model"
 	"github.com/conductor-sdk/conductor-go/sdk/workflow"
 	"github.com/conductor-sdk/conductor-go/test/testdata"
-	"net/http"
-	"testing"
 )
 
 func TestWorkflowTest(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	httpTaskWorkflow := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
 		Name("TEST_GO_WORKFLOW_TEST").
 		Version(1).
@@ -82,6 +85,8 @@ func TestWorkflowTest(t *testing.T) {
 }
 
 func TestJumpToTask(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV52)
+
 	input := workflow.HttpInput{
 		Method: "GET",
 		Uri:    "http://httpbin:8081/api/hello?name=Test123",

--- a/test/integration_tests/workflow_def_test.go
+++ b/test/integration_tests/workflow_def_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestHttpTask(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	httpTaskWorkflow := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
 		Name("TEST_GO_WORKFLOW_HTTP").
 		OwnerEmail("test@orkes.io").
@@ -44,6 +46,8 @@ func TestHttpTask(t *testing.T) {
 }
 
 func SimpleTask(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	err := testdata.ValidateTaskRegistration(*testdata.TestSimpleTask.ToTaskDef())
 	if err != nil {
 		t.Fatal(err)
@@ -86,6 +90,8 @@ func SimpleTask(t *testing.T) {
 }
 
 func SimpleTaskWithoutRetryCount(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	taskToRegister := testdata.TestSimpleTask.ToTaskDef()
 	taskToRegister.RetryCount = 0
 	err := testdata.ValidateTaskRegistration(*taskToRegister)
@@ -130,6 +136,8 @@ func SimpleTaskWithoutRetryCount(t *testing.T) {
 }
 
 func TestInlineTask(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	inlineTaskWorkflow := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
 		Name("TEST_GO_WORKFLOW_INLINE_TASK").
 		Version(1).
@@ -152,6 +160,8 @@ func TestInlineTask(t *testing.T) {
 }
 
 func TestSqsEventTask(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	workflow := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
 		Name("TEST_GO_WORKFLOW_EVENT_SQS").
 		Version(1).
@@ -170,6 +180,8 @@ func TestSqsEventTask(t *testing.T) {
 }
 
 func TestConductorEventTask(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	workflow := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
 		Name("TEST_GO_WORKFLOW_EVENT_CONDUCTOR").
 		Version(1).
@@ -188,6 +200,8 @@ func TestConductorEventTask(t *testing.T) {
 }
 
 func TestKafkaPublishTask(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	workflow := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
 		Name("TEST_GO_WORKFLOW_KAFKA_PUBLISH").
 		Version(1).
@@ -210,6 +224,8 @@ func TestDoWhileTask(t *testing.T) {
 }
 
 func TestTerminateTask(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	workflow := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
 		Name("TEST_GO_WORKFLOW_TERMINATE").
 		Version(1).
@@ -228,6 +244,8 @@ func TestTerminateTask(t *testing.T) {
 }
 
 func TestSwitchTask(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	workflow := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
 		Name("TEST_GO_WORKFLOW_SWITCH").
 		Version(1).
@@ -246,6 +264,8 @@ func TestSwitchTask(t *testing.T) {
 }
 
 func TestDynamicForkWorkflow(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	wf := workflow.NewConductorWorkflow(testdata.WorkflowExecutor).
 		Name("dynamic_workflow_array_sub_workflow").
 		Version(1).
@@ -284,6 +304,8 @@ func createDynamicForkTask() *workflow.DynamicForkTask {
 }
 
 func TestComplexSwitchWorkflow(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	wf := testdata.GetWorkflowWithComplexSwitchTask()
 	err := testdata.ValidateWorkflowRegistration(wf)
 	if err != nil {

--- a/test/integration_tests/workflow_definition_test.go
+++ b/test/integration_tests/workflow_definition_test.go
@@ -18,6 +18,8 @@ import (
 const retryLimit = 5
 
 func TestWorkflowCreation(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 
 	wf := workflow.NewConductorWorkflow(executor).
@@ -71,6 +73,8 @@ func TestWorkflowCreation(t *testing.T) {
 }
 
 func TestRemoveWorkflow(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 	wf := workflow.NewConductorWorkflow(executor)
 	wf.Name("temp_wf_" + strconv.Itoa(time.Now().Nanosecond())).Version(1)
@@ -102,6 +106,8 @@ func TestRemoveWorkflow(t *testing.T) {
 }
 
 func TestExecuteWorkflow(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 	wf := workflow.NewConductorWorkflow(executor).
 		Name("temp_wf_2_" + strconv.Itoa(time.Now().Nanosecond())).
@@ -138,6 +144,8 @@ func TestExecuteWorkflow(t *testing.T) {
 }
 
 func TestExecuteWorkflowWithCorrelationIds(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 	correlationId1 := "correlationId1-" + uuid.New().String()
 	correlationId2 := "correlationId2-" + uuid.New().String()
@@ -175,6 +183,7 @@ func TestExecuteWorkflowWithCorrelationIds(t *testing.T) {
 }
 
 func TestTerminateWorkflowWithFailure(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
 
 	executor := testdata.WorkflowExecutor
 	wf := workflow.NewConductorWorkflow(executor).
@@ -212,6 +221,8 @@ func TestTerminateWorkflowWithFailure(t *testing.T) {
 }
 
 func TestExecuteWorkflowSync(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 	wf := workflow.NewConductorWorkflow(executor).
 		Name("temp_wf_3_" + strconv.Itoa(time.Now().Nanosecond())).

--- a/test/integration_tests/workflow_idempotency_test.go
+++ b/test/integration_tests/workflow_idempotency_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestIdempotencyCombinations(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 	wf := workflow.NewConductorWorkflow(executor)
 	wf.Name("temp_wf_" + strconv.Itoa(time.Now().Nanosecond())).Version(1)
@@ -52,6 +54,8 @@ func TestIdempotencyCombinations(t *testing.T) {
 }
 
 func TestIdempotencyFailOnRunning(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	executor := testdata.WorkflowExecutor
 	wf := workflow.NewConductorWorkflow(executor)
 	wf.Name("temp_wf_" + strconv.Itoa(time.Now().Nanosecond())).Version(1)

--- a/test/integration_tests/workflow_rate_limit_test.go
+++ b/test/integration_tests/workflow_rate_limit_test.go
@@ -18,19 +18,23 @@ import (
 	"github.com/conductor-sdk/conductor-go/sdk/model"
 	"github.com/conductor-sdk/conductor-go/sdk/workflow"
 	"github.com/conductor-sdk/conductor-go/test/testdata"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // TestConcurrentWorkflowExecution tests actual concurrent execution with rate limits
 func TestConcurrentWorkflowExecution(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	testWorkflowExecutor := testdata.WorkflowExecutor
 
 	concurrentLimit := int32(3)
 	duration := 3 * time.Second
-	rateLimitKey := "concurrent_test"
+	uuid := uuid.New().String()
+	rateLimitKey := "concurrent_test" + uuid
 	// Create workflow with strict concurrency limit
-	workflowName := fmt.Sprintf("TEST_GO_WORKFLOW_CONCURRENT_%d", time.Now().Unix())
+	workflowName := fmt.Sprintf("TEST_GO_WORKFLOW_CONCURRENT_%s", uuid)
 	wf := workflow.NewConductorWorkflow(testWorkflowExecutor).
 		Name(workflowName).
 		Version(1).
@@ -44,15 +48,7 @@ func TestConcurrentWorkflowExecution(t *testing.T) {
 	err := wf.Register(true)
 	assert.NoError(t, err)
 
-	// Clean up workflow after test
-	defer func() {
-		err := wf.UnRegister()
-		if err != nil {
-			t.Logf("Failed to unregister workflow: %v", err)
-		}
-	}()
-
-	// Start 15 workflows simultaneously
+	// Start 10 workflows simultaneously
 	var wg sync.WaitGroup
 	ids := make([]string, 10)
 
@@ -63,9 +59,14 @@ func TestConcurrentWorkflowExecution(t *testing.T) {
 			input := map[string]interface{}{
 				"index": idx,
 			}
-			id, err := wf.StartWorkflowWithInput(input)
+			var id string
+			err := testdata.RetryTimeout(3, 500*time.Millisecond, func() error {
+				var startErr error
+				id, startErr = wf.StartWorkflowWithInput(input)
+				return startErr
+			})
 			if err != nil {
-				t.Logf("Failed to start workflow: %v", err)
+				require.NoError(t, err)
 			}
 			ids[idx] = id
 		}(i)
@@ -77,7 +78,10 @@ func TestConcurrentWorkflowExecution(t *testing.T) {
 
 	completedCount := 0
 	for _, id := range ids {
-		execution, _ := testWorkflowExecutor.GetWorkflow(id, true)
+		execution, err := testWorkflowExecutor.GetWorkflow(id, true)
+		require.NoError(t, err)
+		require.NotNil(t, execution)
+
 		switch execution.Status {
 		case model.CompletedWorkflow:
 			completedCount++
@@ -91,16 +95,31 @@ func TestConcurrentWorkflowExecution(t *testing.T) {
 
 	assert.GreaterOrEqual(t, completedCount, int(concurrentLimit), "Completed count should be equal to concurrent limit")
 	assert.Less(t, completedCount, len(ids), "Completed count should be less than or equal to the number of workflows")
+
+	t.Cleanup(func() {
+		for _, id := range ids {
+			err = testdata.WorkflowExecutor.RemoveWorkflow(id)
+			assert.NoError(t, err, "Failed to remove workflow %s", id)
+		}
+
+		err := wf.UnRegister()
+		if err != nil {
+			t.Logf("Failed to unregister workflow: %v", err)
+		}
+	})
 }
 
 // TestPerCustomerRateLimit tests rate limiting per customer ID
 func TestPerCustomerRateLimit(t *testing.T) {
+	testdata.RequireAtLeast(t, testdata.VersionResourceV41)
+
 	testWorkflowExecutor := testdata.WorkflowExecutor
 	concurrentLimit := int32(3)
 	duration := 3 * time.Second
+	uuid := uuid.New().String()
 
 	// Create workflow with per-customer rate limiting
-	workflowName := fmt.Sprintf("TEST_GO_WORKFLOW_CONCURRENT_CUSTOMER_%d", time.Now().Unix())
+	workflowName := fmt.Sprintf("TEST_GO_WORKFLOW_CONCURRENT_CUSTOMER_%s", uuid)
 	wf := workflow.NewConductorWorkflow(testWorkflowExecutor).
 		Name(workflowName).
 		Version(1).
@@ -115,20 +134,12 @@ func TestPerCustomerRateLimit(t *testing.T) {
 	err := wf.Register(true)
 	assert.NoError(t, err)
 
-	// Clean up workflow after test
-	defer func() {
-		err := wf.UnRegister()
-		if err != nil {
-			t.Logf("Failed to unregister workflow: %v", err)
-		}
-	}()
-
 	type CustomerWorkflow struct {
 		CustomerID string
 		WorkflowID string
 	}
 
-	customers := []string{"customer_A", "customer_B"}
+	customers := []string{"customer_A_" + uuid, "customer_B_" + uuid}
 	workflowsPerCustomer := 6
 
 	allWorkflows := make([]CustomerWorkflow, 0)
@@ -147,7 +158,13 @@ func TestPerCustomerRateLimit(t *testing.T) {
 					"index":      idx,
 				}
 
-				id, err := wf.StartWorkflowWithInput(input)
+				var id string
+				err := testdata.RetryTimeout(3, 500*time.Millisecond, func() error {
+					var startErr error
+					id, startErr = wf.StartWorkflowWithInput(input)
+					return startErr
+				})
+				require.NoError(t, err)
 
 				mu.Lock()
 				allWorkflows = append(allWorkflows, CustomerWorkflow{
@@ -155,8 +172,6 @@ func TestPerCustomerRateLimit(t *testing.T) {
 					WorkflowID: id,
 				})
 				mu.Unlock()
-
-				assert.NoError(t, err)
 			}(customerId, i)
 		}
 	}
@@ -178,9 +193,15 @@ func TestPerCustomerRateLimit(t *testing.T) {
 		stats := customerStats[cw.CustomerID]
 
 		// Check if workflow complete
-		execution, err := testWorkflowExecutor.GetWorkflow(cw.WorkflowID, true)
-
+		var execution *model.Workflow
+		err := testdata.RetryTimeout(3, 500*time.Millisecond, func() error {
+			var getErr error
+			execution, getErr = testWorkflowExecutor.GetWorkflow(cw.WorkflowID, true)
+			return getErr
+		})
 		require.NoError(t, err)
+		require.NotEmpty(t, execution)
+
 		switch execution.Status {
 		case model.CompletedWorkflow:
 			stats.Completed++
@@ -212,4 +233,16 @@ func TestPerCustomerRateLimit(t *testing.T) {
 			"Customer %s should have %d running workflows, got %d",
 			customerId, workflowsPerCustomer-stats.Completed, stats.Running)
 	}
+
+	t.Cleanup(func() {
+		for _, id := range allWorkflows {
+			err = testdata.WorkflowExecutor.RemoveWorkflow(id.WorkflowID)
+			assert.NoError(t, err, "Failed to remove workflow %s", id)
+		}
+
+		err := wf.UnRegister()
+		if err != nil {
+			t.Logf("Failed to unregister workflow: %v", err)
+		}
+	})
 }

--- a/test/integration_tests/workflow_rate_limit_test.go
+++ b/test/integration_tests/workflow_rate_limit_test.go
@@ -189,14 +189,9 @@ func TestPerCustomerRateLimit(t *testing.T) {
 		stats := customerStats[cw.CustomerID]
 
 		// Check if workflow complete
-		var execution *model.Workflow
-		err := testdata.RetryTimeout(3, 500*time.Millisecond, func() error {
-			var getErr error
-			execution, getErr = testWorkflowExecutor.GetWorkflow(cw.WorkflowID, true)
-			return getErr
-		})
+		execution, err := testWorkflowExecutor.GetWorkflow(cw.WorkflowID, true)
 		require.NoError(t, err)
-		require.NotEmpty(t, execution)
+		require.NotNil(t, execution)
 
 		switch execution.Status {
 		case model.CompletedWorkflow:

--- a/test/integration_tests/workflow_rate_limit_test.go
+++ b/test/integration_tests/workflow_rate_limit_test.go
@@ -30,7 +30,7 @@ func TestConcurrentWorkflowExecution(t *testing.T) {
 	testWorkflowExecutor := testdata.WorkflowExecutor
 
 	concurrentLimit := int32(3)
-	duration := 3 * time.Second
+	duration := 4 * time.Second
 	uuid := uuid.New().String()
 	rateLimitKey := "concurrent_test" + uuid
 	// Create workflow with strict concurrency limit
@@ -65,16 +65,14 @@ func TestConcurrentWorkflowExecution(t *testing.T) {
 				id, startErr = wf.StartWorkflowWithInput(input)
 				return startErr
 			})
-			if err != nil {
-				require.NoError(t, err)
-			}
+			require.NoError(t, err)
 			ids[idx] = id
 		}(i)
 	}
 
 	wg.Wait()
 
-	time.Sleep(duration + 500*time.Millisecond)
+	time.Sleep(duration + 1*time.Second)
 
 	completedCount := 0
 	for _, id := range ids {
@@ -103,9 +101,7 @@ func TestConcurrentWorkflowExecution(t *testing.T) {
 		}
 
 		err := wf.UnRegister()
-		if err != nil {
-			t.Logf("Failed to unregister workflow: %v", err)
-		}
+		assert.NoError(t, err, "Failed to unregister workflow")
 	})
 }
 
@@ -115,7 +111,7 @@ func TestPerCustomerRateLimit(t *testing.T) {
 
 	testWorkflowExecutor := testdata.WorkflowExecutor
 	concurrentLimit := int32(3)
-	duration := 3 * time.Second
+	duration := 4 * time.Second
 	uuid := uuid.New().String()
 
 	// Create workflow with per-customer rate limiting
@@ -179,7 +175,7 @@ func TestPerCustomerRateLimit(t *testing.T) {
 	wg.Wait()
 
 	// Wait for workflows to complete
-	time.Sleep(duration + 500*time.Millisecond)
+	time.Sleep(duration + 1*time.Second)
 
 	// Analyze results per customer
 	customerStats := make(map[string]struct {
@@ -241,8 +237,6 @@ func TestPerCustomerRateLimit(t *testing.T) {
 		}
 
 		err := wf.UnRegister()
-		if err != nil {
-			t.Logf("Failed to unregister workflow: %v", err)
-		}
+		assert.NoError(t, err, "Failed to unregister workflow")
 	})
 }

--- a/test/testdata/retry_helpers.go
+++ b/test/testdata/retry_helpers.go
@@ -1,0 +1,58 @@
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+//  the License. You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations under the License.
+
+package testdata
+
+import (
+	"strings"
+	"time"
+)
+
+// RetryTimeout executes a function with retries in case of an error
+// maxRetries - maximum number of retry attempts
+// initialBackoff - initial delay between attempts
+// operation - function to execute
+func RetryTimeout(maxRetries int, initialBackoff time.Duration, operation func() error) error {
+	var err error
+	backoff := initialBackoff
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		err = operation()
+		if err == nil {
+			return nil
+		}
+
+		// Check if we need to retry the attempt
+		if attempt == maxRetries || !isRetryableError(err) {
+			return err
+		}
+
+		time.Sleep(backoff)
+
+		// Increase delay for next attempt (simple exponential delay)
+		backoff = backoff * 2
+	}
+
+	return err
+}
+
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := err.Error()
+	return strings.Contains(errStr, "timeout") ||
+		strings.Contains(errStr, "deadline exceeded") ||
+		strings.Contains(errStr, "Client.Timeout exceeded") ||
+		strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "connection reset") ||
+		strings.Contains(errStr, "connection closed") ||
+		strings.Contains(errStr, "EOF")
+}

--- a/test/testdata/util.go
+++ b/test/testdata/util.go
@@ -14,6 +14,9 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
+	"strings"
+	"testing"
 	"time"
 
 	"github.com/conductor-sdk/conductor-go/sdk/model/rbac"
@@ -26,6 +29,12 @@ import (
 	"github.com/conductor-sdk/conductor-go/sdk/workflow/executor"
 
 	"github.com/conductor-sdk/conductor-go/sdk/log"
+	"go.uber.org/zap"
+)
+
+const (
+	VersionResourceV41 = "4.1"
+	VersionResourceV52 = "5.2"
 )
 
 var (
@@ -61,11 +70,26 @@ var (
 	SecretClient          = client.NewSecretsClient(apiClient)
 	WebhookClient         = client.NewWebhooksConfigClient(apiClient)
 	ServiceRegistryClient = client.NewServiceRegistryClient(apiClient)
+	VersionResourceClient = client.NewVersionResourceClient(apiClient)
 )
 
 var TaskRunner = worker.NewTaskRunnerWithApiClient(apiClient)
 
 var WorkflowExecutor = executor.NewWorkflowExecutor(apiClient)
+
+// VersionResource is the version of the Conductor server
+var VersionResource string
+
+func init() {
+	log.SetLogger(log.NewZap(zap.Must(zap.NewProduction())))
+
+	version, _, err := VersionResourceClient.GetVersion(context.Background())
+	if err != nil {
+		log.Fatal("Failed to get version", "error", err)
+	}
+
+	VersionResource = parseVersion(version)
+}
 
 func ReadFile(path string) ([]byte, error) {
 	data, err := os.ReadFile(path)
@@ -351,4 +375,45 @@ func ValidateWorkflowWithOutput(conductorWorkflow *workflow.ConductorWorkflow, t
 		return fmt.Errorf("workflow output is different than expected, workflowId: %s, output: %+v", workflowId, wf.Output)
 	}
 	return nil
+}
+
+func parseVersion(version string) string {
+	parts := strings.Split(version, ".")
+	if len(parts) >= 2 {
+		return parts[0] + "." + parts[1]
+	}
+	return version
+}
+
+func RequireAtLeast(t *testing.T, min string) {
+	t.Helper()
+	have := VersionResource
+
+	if !isVersionAtLeast(have, min) {
+		t.Skipf("skip: requires >= %s, have %s", min, have)
+	}
+}
+
+func isVersionAtLeast(have, min string) bool {
+	haveParts := strings.Split(have, ".")
+	minParts := strings.Split(min, ".")
+
+	if len(haveParts) > 0 && len(minParts) > 0 {
+		haveMajor, _ := strconv.Atoi(haveParts[0])
+		minMajor, _ := strconv.Atoi(minParts[0])
+		if haveMajor < minMajor {
+			return false
+		}
+		if haveMajor > minMajor {
+			return true
+		}
+	}
+
+	if len(haveParts) > 1 && len(minParts) > 1 {
+		haveMinor, _ := strconv.Atoi(haveParts[1])
+		minMinor, _ := strconv.Atoi(minParts[1])
+		return haveMinor >= minMinor
+	}
+
+	return true
 }


### PR DESCRIPTION
### Summary

- Introduced version-aware test execution: tests now detect cluster capabilities at runtime and adapt or skip accordingly.
- Added `VersionResource` client and API (`GET /version`) and wired it via `NewVersionResourceClient`.
- Centralized version parsing and gating helpers in `test/testdata/util.go`:
  - `VersionResource` is read at init.
  - `RequireAtLeast(t, "X.Y")` skips tests if the cluster is below required version.
- Updated integration tests to gate features (e.g., 4.1 and 5.2) using `RequireAtLeast`.
- Added `RetryTimeout` helper with exponential backoff to stabilize flaky network/API calls in tests.