### PR TITLE
test: assert documentation structure, add link validation to CI (3/3)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    name: Validate documentation links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Matches the Java SDK's link validation. --offline keeps CI independent of
+      # third-party site availability; --include-fragments makes the #anchor
+      # targets in CHANGELOG.md real assertions rather than decoration.
+      - name: Validate documentation links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --offline --no-progress --include-fragments README.md CHANGELOG.md docs
+          fail: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@ RUN go build -v ./...
 
 FROM build as test
 COPY /test/unit_tests /package/test/unit_tests
+# docs_test.go asserts on the documentation tree, so it needs the Markdown
+# sources in the image. Without these the documentation tests cannot run in CI.
+COPY /docs /package/docs
+COPY /README.md /package/README.md
+COPY /CHANGELOG.md /package/CHANGELOG.md
 # Run SDK unit tests
 RUN go test -v -race ./sdk/...
 # Run additional unit tests

--- a/test/unit_tests/docs_test.go
+++ b/test/unit_tests/docs_test.go
@@ -44,13 +44,21 @@ var canonicalPages = []string{
 }
 
 // redirectStubs were retired by the move to canonical filenames but are kept as
-// pointer-only files, because conductor-oss/conductor links to them from
-// docs/documentation/clientsdks/go-sdk.md and deleting them would 404 the
+// pointer-only files, because conductor-oss/conductor links to every one of them
+// from docs/documentation/clientsdks/go-sdk.md and deleting them would 404 the
 // published OSS documentation. They are deliberately unreachable from the hub,
 // and must not grow back into guides while they wait to be removed.
+//
+// All six are deleted together once conductor-oss/conductor#1417 repoints those
+// links. Do not add to this list for any other reason: a stub is a bridge for an
+// external referrer, not a way to keep an internal link alive.
 var redirectStubs = []string{
 	"workers_sdk.md",
+	"workflow_sdk.md",
+	"migration_guide.md",
+	"logger_sdk.md",
 	"api_client/README.md",
+	"api_client/tls_configuration.md",
 }
 
 // retiredDocPaths must never be the target of a Markdown link.

--- a/test/unit_tests/docs_test.go
+++ b/test/unit_tests/docs_test.go
@@ -1,0 +1,211 @@
+package unit_tests
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests guard the documentation information architecture this repository
+// adopted from the Java and Python SDKs. See
+// docs/adr/0001-canonical-documentation-ia.md for why the structure looks the way
+// it does.
+//
+// Link *liveness* is not checked here -- the lychee action in
+// .github/workflows/docs.yml does that, and does it better than a hand-rolled
+// walker. These tests assert structure: which pages exist, what stays a stub,
+// what is reachable, and what must not appear at all.
+
+const (
+	repoRoot = "../.."
+	docsDir  = repoRoot + "/docs"
+	docsHub  = docsDir + "/README.md"
+)
+
+// canonicalPages are the cross-SDK page names this repository has adopted. A
+// reader or tool arriving from another Conductor SDK expects to find these names.
+var canonicalPages = []string{
+	"README.md",
+	"compatibility.md",
+	"connection-authentication.md",
+	"core-quickstart.md",
+	"documentation-parity.md",
+	"documentation-standard.md",
+	"observability.md",
+	"security.md",
+	"upgrading.md",
+	"workers.md",
+	"workflows.md",
+}
+
+// redirectStubs were retired by the move to canonical filenames but are kept as
+// pointer-only files, because conductor-oss/conductor links to them from
+// docs/documentation/clientsdks/go-sdk.md and deleting them would 404 the
+// published OSS documentation. They are deliberately unreachable from the hub,
+// and must not grow back into guides while they wait to be removed.
+var redirectStubs = []string{
+	"workers_sdk.md",
+	"api_client/README.md",
+}
+
+// retiredDocPaths must never be the target of a Markdown link.
+//
+// This is asserted against link targets only, never against raw file contents:
+// docs/adr/0001-canonical-documentation-ia.md names these files in prose while
+// describing the renames, which is correct and must not fail the build.
+var retiredDocPaths = []string{
+	"docs/workers_sdk.md",
+	"docs/workflow_sdk.md",
+	"docs/migration_guide.md",
+	"docs/metrics.md",
+	"docs/logger_sdk.md",
+	"docs/api_client/README.md",
+	"docs/api_client/proxy_configuration.md",
+	"docs/api_client/tls_configuration.md",
+}
+
+var markdownLink = regexp.MustCompile(`\[[^\]]*\]\(([^)]+)\)`)
+
+// markdownFiles returns every Markdown file in the repository.
+func markdownFiles(t *testing.T) []string {
+	t.Helper()
+	var found []string
+	err := filepath.Walk(repoRoot, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			if info.Name() == ".git" || info.Name() == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(info.Name(), ".md") {
+			found = append(found, path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, found, "found no Markdown files; is docs/ present in the test image?")
+	return found
+}
+
+// linkTargets returns the repo-relative target of every local Markdown link in
+// file. External URLs, in-page anchors and mailto: links are skipped, and any
+// trailing #fragment is trimmed.
+func linkTargets(t *testing.T, file string) []string {
+	t.Helper()
+	body, err := os.ReadFile(file)
+	require.NoErrorf(t, err, "could not read %s", file)
+
+	var targets []string
+	for _, match := range markdownLink.FindAllStringSubmatch(string(body), -1) {
+		target := strings.TrimSpace(match[1])
+		if target == "" || strings.Contains(target, "://") ||
+			strings.HasPrefix(target, "#") || strings.HasPrefix(target, "mailto:") {
+			continue
+		}
+		if hash := strings.IndexByte(target, '#'); hash >= 0 {
+			target = target[:hash]
+		}
+		if target == "" {
+			continue
+		}
+		rel, relErr := filepath.Rel(repoRoot, filepath.Join(filepath.Dir(file), target))
+		require.NoError(t, relErr)
+		targets = append(targets, filepath.ToSlash(rel))
+	}
+	return targets
+}
+
+func TestCanonicalDocumentationPagesExist(t *testing.T) {
+	for _, page := range canonicalPages {
+		_, err := os.Stat(filepath.Join(docsDir, page))
+		assert.NoErrorf(t, err,
+			"canonical page docs/%s is missing; see docs/adr/0001-canonical-documentation-ia.md", page)
+	}
+}
+
+func TestRedirectStubsRemainPointersOnly(t *testing.T) {
+	const maxStubLines = 20
+
+	for _, stub := range redirectStubs {
+		path := filepath.Join(docsDir, stub)
+
+		body, err := os.ReadFile(path)
+		require.NoErrorf(t, err,
+			"redirect stub docs/%s is missing; conductor-oss/conductor links to that path", stub)
+		content := string(body)
+
+		lines := strings.Count(strings.TrimSpace(content), "\n") + 1
+		assert.LessOrEqualf(t, lines, maxStubLines,
+			"redirect stub docs/%s has grown to %d lines; it must stay a pointer, not become a guide", stub, lines)
+		assert.Containsf(t, content, "redirect stub",
+			"docs/%s must say it is a redirect stub, so the next reader knows not to add content", stub)
+		assert.NotContainsf(t, content, "```",
+			"redirect stub docs/%s contains a code block, which means it is turning back into a guide", stub)
+		assert.NotEmptyf(t, linkTargets(t, path),
+			"redirect stub docs/%s must link to its replacement", stub)
+	}
+}
+
+func TestNoLinksToRetiredDocumentationPaths(t *testing.T) {
+	retired := make(map[string]bool, len(retiredDocPaths))
+	for _, path := range retiredDocPaths {
+		retired[path] = true
+	}
+
+	for _, file := range markdownFiles(t) {
+		for _, target := range linkTargets(t, file) {
+			assert.Falsef(t, retired[target],
+				"%s links to retired path %s; use the canonical page instead", file, target)
+		}
+	}
+}
+
+func TestEveryDocumentationPageIsReachableFromHub(t *testing.T) {
+	linked := make(map[string]bool)
+	for _, target := range linkTargets(t, docsHub) {
+		linked[target] = true
+	}
+
+	isStub := make(map[string]bool, len(redirectStubs))
+	for _, stub := range redirectStubs {
+		isStub[filepath.ToSlash(filepath.Join("docs", stub))] = true
+	}
+
+	pages, err := filepath.Glob(filepath.Join(docsDir, "*.md"))
+	require.NoError(t, err)
+
+	for _, page := range pages {
+		rel, relErr := filepath.Rel(repoRoot, page)
+		require.NoError(t, relErr)
+		rel = filepath.ToSlash(rel)
+
+		if rel == "docs/README.md" || isStub[rel] {
+			continue
+		}
+		assert.Truef(t, linked[rel],
+			"%s is not linked from docs/README.md; an orphan page is invisible, which is how the "+
+				"documentation drifted out of parity in the first place", rel)
+	}
+}
+
+func TestNoAgentDocumentationTree(t *testing.T) {
+	_, err := os.Stat(filepath.Join(docsDir, "agents"))
+	assert.Truef(t, os.IsNotExist(err),
+		"docs/agents/ exists, but this SDK provides no Conductor agent runtime. The absence is recorded "+
+			"in docs/compatibility.md and docs/documentation-parity.md rather than as an empty page tree.")
+
+	for _, file := range markdownFiles(t) {
+		for _, target := range linkTargets(t, file) {
+			assert.NotContainsf(t, target, "docs/agents/",
+				"%s links into docs/agents/, which does not exist in this SDK", file)
+		}
+	}
+}


### PR DESCRIPTION
Third of three PRs aligning this SDK's documentation information architecture with the [Java](https://github.com/conductor-oss/java-sdk/tree/main/docs) and [Python](https://github.com/conductor-oss/python-sdk/tree/main/docs) SDKs.

**Stacked on #274, which is stacked on #273.** Merge in order.

This PR codifies the end state the first two PRs produced, so it lands last — running it first would just fail red against pages that did not exist yet.

## Split by what each tool is good at

The Java SDK does all of its documentation validation with shell `grep` steps in `ci.yml`. That is not the Go idiom, and it has a real cost: a contributor cannot run it. But hand-rolling a link checker in Go would mean reimplementing anchor resolution, fragment matching, and relative-path normalization that lychee already does — and diverging from the sibling repos' link semantics. So:

| Concern | Tool | Runs locally? |
|---|---|---|
| Structure | `test/unit_tests/docs_test.go` | Yes — `go test ./...` |
| Link liveness | `lycheeverse/lychee-action@v2` | CI |

## What the Go test asserts

1. **The canonical page set exists** — the 11 pages a reader arriving from another SDK expects.
2. **The two redirect stubs stay pointer-only** — line count under 20, no code fences, and they must still link to their replacement. They exist only until `conductor-oss/conductor` updates its links, and this stops them quietly growing back into guides in the meantime.
3. **No Markdown link targets a retired path.** Asserted against *link targets*, never raw file contents — `docs/adr/0001` names `metrics.md`, `logger_sdk.md` and friends in prose while describing the renames, and a naive string grep (Java's approach) would fail the build on the very document that explains the change.
4. **Every `docs/*.md` is reachable from the hub.** Orphan pages are the drift mechanism that produced this whole exercise.
5. **`docs/agents/` does not exist and nothing links into it.**

## Dockerfile change

`build.yml` runs tests via `docker build --target=test`, and that stage previously copied only `sdk/`, `go.mod`, `go.sum`, and `test/unit_tests/`. A test that walks `docs/` would pass locally and fail in CI. The stage now also copies `docs/`, `README.md`, and `CHANGELOG.md`. The `inttest` and `harness-build` stages derive from `build`, not `test`, so they are unaffected.

## Verification — read this before approving

**I could not execute the Go test locally.** There is no Go toolchain on this machine and the Docker daemon is not running, so neither `go test` nor `docker build --target=test` could run. **CI is the first real execution of this test.** I am flagging that rather than implying it was verified.

What I did verify:

- No symbol collisions with the 5 existing files in `package unit_tests` — every new identifier appears only in `docs_test.go`
- Each of the 5 assertions replicated in shell against the working tree, all passing: 11 canonical pages present; stubs at 10 and 12 lines with 0 code fences and a link each; no link to any retired path across all 7 Markdown files in the repo; no orphans; `docs/agents/` absent with no relative links into it

The unverified risk is compilation, not logic. If CI goes red, that is where it will be.

One flag on `--include-fragments`: it is what makes the preserved `CHANGELOG.md` anchors a real check rather than decoration, but I have not confirmed the flag is supported by the lychee version this action resolves to. If it is rejected, dropping the flag still leaves link-path validation working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Correction: six stubs, not two

An earlier revision of this description referred to "the two redirect stubs". The real number is **six** — `gh search code` truncated the result the original count came from, and reading `conductor-oss/conductor`'s `docs/documentation/clientsdks/go-sdk.md` directly shows nine links across six retired paths.

`redirectStubs` in `docs_test.go` now lists all six. Without that change the hub-reachability assertion fails, because `docs/*.md` matches the four stubs added in #273 and #274.

Repointing the upstream links is tracked in **conductor-oss/conductor#1417**; all six stubs are deleted together once it lands. The list carries a comment saying not to extend it for any other reason — a stub is a bridge for an external referrer, not a way to keep an internal link alive.
