### PR TITLE
fix(scheduler): PUT with GET fallback for per-schedule pause/resume

### DIFF
--- a/sdk/client/api_scheduler_resource.go
+++ b/sdk/client/api_scheduler_resource.go
@@ -194,22 +194,14 @@ func (a *SchedulerResourceApiService) PauseSchedule(ctx context.Context, name st
 	return a.putThenGet(ctx, path)
 }
 
-// putThenGet issues a PUT and falls back to a GET if the server rejects it with a
-// 4xx. It exists because the verb accepted for per-schedule pause/resume differs by
-// deployment:
+// putThenGet issues a PUT and falls back to a GET on 405.
 //
-//	OSS Conductor                  PUT only  (GET returns 405)
-//	Orkes Conductor >= 2026-07-14  PUT or GET
-//	Orkes Conductor <  2026-07-14  GET only  (PUT returns 405)
+// OSS Conductor accepts only PUT on these endpoints. Orkes accepted only GET before
+// 2026-07-14 and accepts both since. PUT first therefore works everywhere, and the
+// fallback can be dropped once no supported server needs GET.
 //
-// PUT is the RESTful verb and the only one upstream OSS accepts, so it is tried
-// first. GET is attempted only when PUT is refused with a 405, which keeps older
-// Orkes deployments working while converging on PUT as they age out. Once no
-// supported server predates PUT, this helper can be reduced to a plain PUT.
-//
-// The fallback is deliberately narrow: a 5xx, a transport error, or any 4xx other
-// than 405 is returned as-is, since retrying those with a different verb would mask
-// the real fault and report it as a method problem.
+// Only 405 falls back; any other status is returned as-is, since retrying it would
+// report a method problem instead of the real cause.
 func (a *SchedulerResourceApiService) putThenGet(ctx context.Context, path string) (interface{}, *http.Response, error) {
 	var result interface{}
 
@@ -218,16 +210,11 @@ func (a *SchedulerResourceApiService) putThenGet(ctx context.Context, path strin
 		return result, resp, nil
 	}
 
-	// 405 is the only status that means "wrong verb". Other 4xx have distinct causes
-	// — 404 for a missing schedule or absent scheduler module, 401/403 for auth — and
-	// retrying those with GET would just repeat the failure while reporting it as a
-	// method problem.
 	var swaggerErr GenericSwaggerError
 	if !errors.As(err, &swaggerErr) || swaggerErr.StatusCode() != http.StatusMethodNotAllowed {
 		return nil, resp, err
 	}
 
-	// Legacy deployments expose these endpoints as GET.
 	result = nil
 	getResp, getErr := a.Get(ctx, path, nil, &result)
 	if getErr != nil {

--- a/sdk/client/api_scheduler_resource.go
+++ b/sdk/client/api_scheduler_resource.go
@@ -11,6 +11,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/antihax/optional"
 	"github.com/conductor-sdk/conductor-go/sdk/metrics"
@@ -187,15 +188,50 @@ SchedulerResourceApiService Pauses an existing schedule by name
     @return interface{}
 */
 func (a *SchedulerResourceApiService) PauseSchedule(ctx context.Context, name string) (interface{}, *http.Response, error) {
-	var result interface{}
 	ctx = metrics.WithPathTemplate(ctx, "/scheduler/schedules/{name}/pause")
 	path := fmt.Sprintf("/scheduler/schedules/%s/pause", name)
 
-	resp, err := a.Get(ctx, path, nil, &result)
-	if err != nil {
+	return a.putThenGet(ctx, path)
+}
+
+// putThenGet issues a PUT and falls back to a GET if the server rejects it with a
+// 4xx. It exists because the verb accepted for per-schedule pause/resume differs by
+// deployment:
+//
+//	OSS Conductor                  PUT only  (GET returns 405)
+//	Orkes Conductor >= 2026-07-14  PUT or GET
+//	Orkes Conductor <  2026-07-14  GET only  (PUT returns 405)
+//
+// PUT is the RESTful verb and the only one upstream OSS accepts, so it is tried
+// first. GET is attempted only when PUT is refused with a 4xx, which keeps older
+// Orkes deployments working while converging on PUT as they age out. Once no
+// supported server predates PUT, this helper can be reduced to a plain PUT.
+//
+// The fallback is deliberately limited to 4xx: retrying a 5xx or a transport error
+// with a different verb would mask the real fault and report it as a method problem.
+func (a *SchedulerResourceApiService) putThenGet(ctx context.Context, path string) (interface{}, *http.Response, error) {
+	var result interface{}
+
+	resp, err := a.Put(ctx, path, nil, &result)
+	if err == nil {
+		return result, resp, nil
+	}
+
+	var swaggerErr GenericSwaggerError
+	if !errors.As(err, &swaggerErr) {
 		return nil, resp, err
 	}
-	return result, resp, nil
+	if code := swaggerErr.StatusCode(); code < 400 || code >= 500 {
+		return nil, resp, err
+	}
+
+	// Legacy deployments expose these endpoints as GET.
+	result = nil
+	getResp, getErr := a.Get(ctx, path, nil, &result)
+	if getErr != nil {
+		return nil, getResp, getErr
+	}
+	return result, getResp, nil
 }
 
 /*
@@ -256,15 +292,10 @@ SchedulerResourceApiService Resume a paused schedule by name
     @return interface{}
 */
 func (a *SchedulerResourceApiService) ResumeSchedule(ctx context.Context, name string) (interface{}, *http.Response, error) {
-	var result interface{}
-
 	ctx = metrics.WithPathTemplate(ctx, "/scheduler/schedules/{name}/resume")
 	path := fmt.Sprintf("/scheduler/schedules/%s/resume", name)
-	resp, err := a.Get(ctx, path, nil, &result)
-	if err != nil {
-		return nil, resp, err
-	}
-	return result, resp, nil
+
+	return a.putThenGet(ctx, path)
 }
 
 /*

--- a/sdk/client/api_scheduler_resource.go
+++ b/sdk/client/api_scheduler_resource.go
@@ -203,12 +203,13 @@ func (a *SchedulerResourceApiService) PauseSchedule(ctx context.Context, name st
 //	Orkes Conductor <  2026-07-14  GET only  (PUT returns 405)
 //
 // PUT is the RESTful verb and the only one upstream OSS accepts, so it is tried
-// first. GET is attempted only when PUT is refused with a 4xx, which keeps older
+// first. GET is attempted only when PUT is refused with a 405, which keeps older
 // Orkes deployments working while converging on PUT as they age out. Once no
 // supported server predates PUT, this helper can be reduced to a plain PUT.
 //
-// The fallback is deliberately limited to 4xx: retrying a 5xx or a transport error
-// with a different verb would mask the real fault and report it as a method problem.
+// The fallback is deliberately narrow: a 5xx, a transport error, or any 4xx other
+// than 405 is returned as-is, since retrying those with a different verb would mask
+// the real fault and report it as a method problem.
 func (a *SchedulerResourceApiService) putThenGet(ctx context.Context, path string) (interface{}, *http.Response, error) {
 	var result interface{}
 
@@ -217,11 +218,12 @@ func (a *SchedulerResourceApiService) putThenGet(ctx context.Context, path strin
 		return result, resp, nil
 	}
 
+	// 405 is the only status that means "wrong verb". Other 4xx have distinct causes
+	// — 404 for a missing schedule or absent scheduler module, 401/403 for auth — and
+	// retrying those with GET would just repeat the failure while reporting it as a
+	// method problem.
 	var swaggerErr GenericSwaggerError
-	if !errors.As(err, &swaggerErr) {
-		return nil, resp, err
-	}
-	if code := swaggerErr.StatusCode(); code < 400 || code >= 500 {
+	if !errors.As(err, &swaggerErr) || swaggerErr.StatusCode() != http.StatusMethodNotAllowed {
 		return nil, resp, err
 	}
 

--- a/sdk/client/api_scheduler_resource_test.go
+++ b/sdk/client/api_scheduler_resource_test.go
@@ -102,6 +102,22 @@ func TestPauseScheduleVerbNegotiation(t *testing.T) {
 			wantMethods: []string{http.MethodPut, http.MethodGet},
 			wantErr:     true,
 		},
+		{
+			// Only 405 means "wrong verb". A 404 means the schedule or the scheduler
+			// module is absent, so a GET retry would repeat the failure and report it
+			// as a method problem.
+			name:        "404 does not trigger the fallback",
+			allow:       map[string]int{http.MethodPut: http.StatusNotFound},
+			wantMethods: []string{http.MethodPut},
+			wantErr:     true,
+		},
+		{
+			// Likewise for auth failures.
+			name:        "401 does not trigger the fallback",
+			allow:       map[string]int{http.MethodPut: http.StatusUnauthorized},
+			wantMethods: []string{http.MethodPut},
+			wantErr:     true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/sdk/client/api_scheduler_resource_test.go
+++ b/sdk/client/api_scheduler_resource_test.go
@@ -18,19 +18,14 @@ import (
 	"github.com/conductor-sdk/conductor-go/sdk/settings"
 )
 
-// PauseSchedule and ResumeSchedule have to work against three server generations
-// that accept different verbs. No single live server exercises all of them, so they
-// are modelled here with stub handlers that record the verbs they receive — letting
-// the tests assert not only that the call succeeds but that the client prefers PUT
-// and falls back only when refused.
+// Stub servers stand in for the server generations that accept different verbs,
+// recording what they receive so the tests can assert PUT is preferred.
 
 type verbSpy struct {
 	methods []string
 	paths   []string
 }
 
-// handler answers with the status configured for the received method, or 405 when
-// the method is not in the map.
 func (v *verbSpy) handler(allow map[string]int) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		v.methods = append(v.methods, r.Method)
@@ -74,14 +69,12 @@ func TestPauseScheduleVerbNegotiation(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			// Upstream OSS Conductor declares these endpoints @PutMapping.
 			name:        "server accepts put only",
 			allow:       map[string]int{http.MethodPut: http.StatusOK},
 			wantMethods: []string{http.MethodPut},
 		},
 		{
-			// Orkes Conductor from 2026-07-14 accepts both; PUT must be preferred so
-			// callers converge on it and the fallback can eventually be removed.
+			// PUT must win so callers converge on it.
 			name: "server accepts both, put preferred",
 			allow: map[string]int{
 				http.MethodPut: http.StatusOK,
@@ -90,29 +83,24 @@ func TestPauseScheduleVerbNegotiation(t *testing.T) {
 			wantMethods: []string{http.MethodPut},
 		},
 		{
-			// Orkes Conductor before 2026-07-14 accepts GET only.
 			name:        "legacy server falls back to get",
 			allow:       map[string]int{http.MethodGet: http.StatusOK},
 			wantMethods: []string{http.MethodPut, http.MethodGet},
 		},
 		{
-			// Neither verb accepted: report the failure rather than claim success.
 			name:        "neither verb accepted returns error",
 			allow:       map[string]int{},
 			wantMethods: []string{http.MethodPut, http.MethodGet},
 			wantErr:     true,
 		},
 		{
-			// Only 405 means "wrong verb". A 404 means the schedule or the scheduler
-			// module is absent, so a GET retry would repeat the failure and report it
-			// as a method problem.
+			// 404 means the schedule or scheduler module is absent, not a bad verb.
 			name:        "404 does not trigger the fallback",
 			allow:       map[string]int{http.MethodPut: http.StatusNotFound},
 			wantMethods: []string{http.MethodPut},
 			wantErr:     true,
 		},
 		{
-			// Likewise for auth failures.
 			name:        "401 does not trigger the fallback",
 			allow:       map[string]int{http.MethodPut: http.StatusUnauthorized},
 			wantMethods: []string{http.MethodPut},
@@ -138,8 +126,7 @@ func TestPauseScheduleVerbNegotiation(t *testing.T) {
 }
 
 func TestResumeScheduleVerbNegotiation(t *testing.T) {
-	// Resume shares the helper with pause; this guards against only one of the two
-	// being wired up.
+	// Guards against only one of the two methods being wired up.
 	spy := &verbSpy{}
 	svc, _ := newSchedulerService(t, spy.handler(map[string]int{http.MethodGet: http.StatusOK}))
 
@@ -154,8 +141,7 @@ func TestResumeScheduleVerbNegotiation(t *testing.T) {
 	}
 }
 
-// A 5xx must not trigger the fallback: retrying a server fault with a different verb
-// would hide it behind a misleading "method not supported".
+// A 5xx must not trigger the fallback; it would hide the fault behind a verb error.
 func TestPauseScheduleDoesNotFallBackOnServerError(t *testing.T) {
 	spy := &verbSpy{}
 	svc, _ := newSchedulerService(t, spy.handler(map[string]int{

--- a/sdk/client/api_scheduler_resource_test.go
+++ b/sdk/client/api_scheduler_resource_test.go
@@ -1,0 +1,154 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/conductor-sdk/conductor-go/sdk/settings"
+)
+
+// PauseSchedule and ResumeSchedule have to work against three server generations
+// that accept different verbs. No single live server exercises all of them, so they
+// are modelled here with stub handlers that record the verbs they receive — letting
+// the tests assert not only that the call succeeds but that the client prefers PUT
+// and falls back only when refused.
+
+type verbSpy struct {
+	methods []string
+	paths   []string
+}
+
+// handler answers with the status configured for the received method, or 405 when
+// the method is not in the map.
+func (v *verbSpy) handler(allow map[string]int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		v.methods = append(v.methods, r.Method)
+		v.paths = append(v.paths, r.URL.EscapedPath())
+		if code, ok := allow[r.Method]; ok {
+			w.WriteHeader(code)
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func newSchedulerService(t *testing.T, h http.Handler) (*SchedulerResourceApiService, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	api := NewAPIClient(
+		settings.NewAuthenticationSettings("", ""),
+		settings.NewHttpSettings(srv.URL+"/api"),
+	)
+	return &SchedulerResourceApiService{APIClient: api}, srv
+}
+
+func assertMethods(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("methods = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("methods = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestPauseScheduleVerbNegotiation(t *testing.T) {
+	tests := []struct {
+		name        string
+		allow       map[string]int
+		wantMethods []string
+		wantErr     bool
+	}{
+		{
+			// Upstream OSS Conductor declares these endpoints @PutMapping.
+			name:        "server accepts put only",
+			allow:       map[string]int{http.MethodPut: http.StatusOK},
+			wantMethods: []string{http.MethodPut},
+		},
+		{
+			// Orkes Conductor from 2026-07-14 accepts both; PUT must be preferred so
+			// callers converge on it and the fallback can eventually be removed.
+			name: "server accepts both, put preferred",
+			allow: map[string]int{
+				http.MethodPut: http.StatusOK,
+				http.MethodGet: http.StatusOK,
+			},
+			wantMethods: []string{http.MethodPut},
+		},
+		{
+			// Orkes Conductor before 2026-07-14 accepts GET only.
+			name:        "legacy server falls back to get",
+			allow:       map[string]int{http.MethodGet: http.StatusOK},
+			wantMethods: []string{http.MethodPut, http.MethodGet},
+		},
+		{
+			// Neither verb accepted: report the failure rather than claim success.
+			name:        "neither verb accepted returns error",
+			allow:       map[string]int{},
+			wantMethods: []string{http.MethodPut, http.MethodGet},
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spy := &verbSpy{}
+			svc, _ := newSchedulerService(t, spy.handler(tt.allow))
+
+			_, _, err := svc.PauseSchedule(context.Background(), "probe")
+			if tt.wantErr && err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			assertMethods(t, spy.methods, tt.wantMethods)
+		})
+	}
+}
+
+func TestResumeScheduleVerbNegotiation(t *testing.T) {
+	// Resume shares the helper with pause; this guards against only one of the two
+	// being wired up.
+	spy := &verbSpy{}
+	svc, _ := newSchedulerService(t, spy.handler(map[string]int{http.MethodGet: http.StatusOK}))
+
+	if _, _, err := svc.ResumeSchedule(context.Background(), "probe"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertMethods(t, spy.methods, []string{http.MethodPut, http.MethodGet})
+	for _, p := range spy.paths {
+		if p != "/api/scheduler/schedules/probe/resume" {
+			t.Fatalf("path = %q, want the resume endpoint", p)
+		}
+	}
+}
+
+// A 5xx must not trigger the fallback: retrying a server fault with a different verb
+// would hide it behind a misleading "method not supported".
+func TestPauseScheduleDoesNotFallBackOnServerError(t *testing.T) {
+	spy := &verbSpy{}
+	svc, _ := newSchedulerService(t, spy.handler(map[string]int{
+		http.MethodPut: http.StatusInternalServerError,
+		http.MethodGet: http.StatusOK,
+	}))
+
+	if _, _, err := svc.PauseSchedule(context.Background(), "probe"); err == nil {
+		t.Fatal("expected the 500 to surface, got nil")
+	}
+	assertMethods(t, spy.methods, []string{http.MethodPut})
+}


### PR DESCRIPTION
## Problem

`PauseSchedule` and `ResumeSchedule` send `GET`, but OSS Conductor only accepts `PUT` on both
endpoints. Every call against an OSS server fails:

```
Request method 'GET' is not supported (status: 405)
```

Swapping `GET` for `PUT` is not enough — the accepted verb depends on the deployment:

| Deployment | GET | PUT |
|---|---|---|
| OSS Conductor (main, 3.32.0-rc.23) | 405 | 200 |
| Orkes >= 2026-07-14 | 200 | 200 |
| Orkes < 2026-07-14 | 200 | 405 |

Orkes only added `PUT` on 2026-07-14 (orkes-conductor `1854375f0c`), so hardcoding `PUT` would fix
OSS and break older Orkes.

## Change

Both methods now go through `putThenGet`: send `PUT`, fall back to `GET` only on a 405. That covers
all three rows and keeps existing callers unchanged.

Fallback is limited to 405 on purpose. Any other status means something other than the verb is
wrong, and retrying it would report a method problem instead of the real cause.

## Tests

Stub servers cover all three deployments plus a server that accepts neither verb, and record which
verb they received — so the tests check that the client prefers `PUT`, not just that the call
succeeds. Also covered: 404, 401 and 500 do not trigger the fallback, and `resume` hits its own
endpoint.

## How to test

Built the Conductor CLI unmodified against this branch, ran it against OSS Conductor from `main`:

```console
$ conductor schedule pause sdkfix_probe     # exit 0, "paused": true
$ conductor schedule resume sdkfix_probe    # exit 0, paused cleared
```

Both returned 405 before. No CLI change was needed.

Reported as conductor-oss/conductor-cli#101. Not caught by that repo's CI, which only runs against
Orkes.
