### PR TITLE
fix: three unrelated v5 integration failures (jump path, retry assertion, bulk delete race)

### DIFF
--- a/sdk/client/api_workflow_resource.go
+++ b/sdk/client/api_workflow_resource.go
@@ -964,14 +964,11 @@ type WorkflowResourceApiJumpToTaskOpts struct {
 }
 
 // JumpToTask jumps to a specific task in a running workflow.
-//
-// The task reference goes in the path — the server route is
-// /workflow/{workflowId}/jump/{taskReferenceName} and returns 404 without that
-// segment. It is also sent as a query parameter because the handler reads the value
-// from there rather than from the path.
 func (a *WorkflowResourceApiService) JumpToTask(ctx context.Context, body map[string]interface{}, workflowId string, optionals *WorkflowResourceApiJumpToTaskOpts) (*http.Response, error) {
 	ctx = metrics.WithPathTemplate(ctx, "/workflow/{workflowId}/jump/{taskReferenceName}")
 
+	// Sent in the path and the query: the route needs the segment, the handler binds
+	// the value from the query parameter.
 	queryParams := url.Values{}
 	taskReferenceName := ""
 	if optionals != nil && optionals.TaskReferenceName.IsSet() {

--- a/sdk/client/api_workflow_resource.go
+++ b/sdk/client/api_workflow_resource.go
@@ -964,14 +964,22 @@ type WorkflowResourceApiJumpToTaskOpts struct {
 }
 
 // JumpToTask jumps to a specific task in a running workflow.
+//
+// The task reference goes in the path — the server route is
+// /workflow/{workflowId}/jump/{taskReferenceName} and returns 404 without that
+// segment. It is also sent as a query parameter because the handler reads the value
+// from there rather than from the path.
 func (a *WorkflowResourceApiService) JumpToTask(ctx context.Context, body map[string]interface{}, workflowId string, optionals *WorkflowResourceApiJumpToTaskOpts) (*http.Response, error) {
-	ctx = metrics.WithPathTemplate(ctx, "/workflow/{workflowId}/jump")
-	path := fmt.Sprintf("/workflow/%s/jump", workflowId)
+	ctx = metrics.WithPathTemplate(ctx, "/workflow/{workflowId}/jump/{taskReferenceName}")
 
 	queryParams := url.Values{}
+	taskReferenceName := ""
 	if optionals != nil && optionals.TaskReferenceName.IsSet() {
-		queryParams.Add("taskReferenceName", parameterToString(optionals.TaskReferenceName.Value(), ""))
+		taskReferenceName = parameterToString(optionals.TaskReferenceName.Value(), "")
+		queryParams.Add("taskReferenceName", taskReferenceName)
 	}
+
+	path := fmt.Sprintf("/workflow/%s/jump/%s", workflowId, url.PathEscape(taskReferenceName))
 
 	resp, err := a.PostWithParams(ctx, path, queryParams, body, nil)
 	if err != nil {

--- a/test/integration_tests/workflow_bulk_client_test.go
+++ b/test/integration_tests/workflow_bulk_client_test.go
@@ -76,11 +76,21 @@ func TestWorkflowBulkDelete(t *testing.T) {
 	assert.Equal(t, len(response.BulkSuccessfulResults), len(workflowIds),
 		"Bulk successful results should be equal to workflow count")
 
-	// Verify workflows are deleted
+	// Verify workflows are deleted. Bulk delete is accepted before it has taken effect,
+	// so poll rather than reading once — a single immediate read is a race that shows up
+	// intermittently in CI.
 	for _, id := range workflowIds {
-		_, err := testdata.WorkflowExecutor.GetWorkflow(id, false)
-		require.Error(t, err, "Workflow %s should be deleted", id)
-		assert.Contains(t, err.Error(), "no such workflow by Id", "Error should indicate workflow not found")
+		var lastErr error
+		deadline := time.Now().Add(testdata.WorkflowValidationTimeout)
+		for time.Now().Before(deadline) {
+			_, lastErr = testdata.WorkflowExecutor.GetWorkflow(id, false)
+			if lastErr != nil {
+				break
+			}
+			time.Sleep(250 * time.Millisecond)
+		}
+		require.Error(t, lastErr, "Workflow %s should be deleted", id)
+		assert.Contains(t, lastErr.Error(), "no such workflow by Id", "Error should indicate workflow not found")
 	}
 }
 

--- a/test/integration_tests/workflow_definition_test.go
+++ b/test/integration_tests/workflow_definition_test.go
@@ -603,15 +603,34 @@ func TestRetryWorkflowWithDecide(t *testing.T) {
 	assert.NoError(t, err, "Failed to wait for workflow to fail")
 	assert.Equal(t, model.FailedWorkflow, failedWorkflow.Status, "Workflow should be failed")
 
+	tasksBeforeRetry := len(failedWorkflow.Tasks)
+
 	_, err = testdata.WorkflowClient.Retry(context.Background(), workflowId, nil)
 	assert.NoError(t, err, "Failed to retry workflow")
 
-	// Verify workflow is running after retry
-	workflowAfterRetry, err := testdata.WaitForWorkflowStatus(workflowId,
-		[]model.WorkflowStatus{model.RunningWorkflow}, testdata.WorkflowValidationTimeout)
+	// Assert on the fresh task attempt rather than on a transient RUNNING status.
+	// This workflow's only task throws immediately, so on a fast server it fails again
+	// before any poll can observe RUNNING — which made the previous assertion depend on
+	// server speed. What retry actually guarantees is a new attempt of the failed task.
+	var workflowAfterRetry *model.Workflow
+	deadline := time.Now().Add(testdata.WorkflowValidationTimeout)
+	for time.Now().Before(deadline) {
+		workflowAfterRetry, err = testdata.WorkflowExecutor.GetWorkflow(workflowId, true)
+		if err == nil && len(workflowAfterRetry.Tasks) > tasksBeforeRetry {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 	assert.NoError(t, err, "Failed to get workflow after retry")
-	assert.Equal(t, model.RunningWorkflow, workflowAfterRetry.Status, "Workflow should be running after retry")
+	require.NotNil(t, workflowAfterRetry, "Expected to read the workflow after retry")
+	assert.Greater(t, len(workflowAfterRetry.Tasks), tasksBeforeRetry,
+		"Retry should add a new attempt of the failed task")
 	assert.Equal(t, workflowId, workflowAfterRetry.WorkflowId, "Workflow ID should be the same")
+
+	lastAttempt := workflowAfterRetry.Tasks[len(workflowAfterRetry.Tasks)-1]
+	assert.Equal(t, "failing_inline_task", lastAttempt.ReferenceTaskName,
+		"Newest attempt should be of the task that failed")
+	assert.Greater(t, lastAttempt.RetryCount, int32(0), "Newest attempt should be a retry")
 
 	_, err = testdata.WorkflowClient.Decide(context.Background(), workflowId)
 	assert.NoError(t, err, "Failed to trigger decide")


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

The `v5 - integration` job has been red since late July, blocking this repo (nothing has merged since
#255). It is three unrelated problems, not one flaky test. All three are fixed and the full
integration suite now passes against the v5 cluster: 170s, 0 failures.

Not caused by any PR: `main` was green on 2026-07-09 with both clusters passing, no commits have
landed on `main` since, and the same tests fail on unrelated branches. The v5 cluster changed, not
the SDK.

1. `TestJumpToTask` — real SDK defect. `JumpToTask` posted to `/workflow/{id}/jump` with the task
   reference as a query param, but the route is `/workflow/{id}/jump/{taskReferenceName}` and 404s
   without that segment. Now sent in the path, and still as a query param because the handler
   declares it `@RequestParam` and reads the value from there. No back-compat shim needed: the test
   is gated on server >= 5.2 and reports SKIPPED on v4, so it has only ever run on v5.

2. `TestRetryWorkflowWithDecide` — test defect. It waited for `RUNNING` after `Retry`, but the
   workflow's only task throws immediately, so it fails again before any poll observes `RUNNING`.
   Passes on the slower cluster, fails every time on the faster one. Retry itself was correct, it
   does create a new attempt. Now asserts that attempt with a bounded poll.

3. `TestWorkflowBulkDelete` — test defect. It read each workflow once immediately after bulk delete
   and required the read to fail, racing the deletion. Now polls. Not reproducible on demand, so this
   fix is reasoned from the failure mode rather than observed going red then green.

Verified locally against the v5 cluster (5.2.92): all three pass and the full suite is green.
`JumpToTask` is shared, so the whole suite was run rather than these three alone.

Issue #
Found while investigating why #276 cannot merge — a scheduler fix for
conductor-oss/conductor-cli#101, blocked purely by this red job.

Alternatives considered
----

Skip or quarantine the three tests on v5. Rejected: two are real bugs and one is in shipped SDK code.

Add a path/query fallback for `JumpToTask`, as done for the scheduler in #276. Unnecessary here,
since the test is version-gated above v4 and no older server exercises this call.

Widen the retry assertion to "RUNNING or FAILED". Rejected: those are the only reachable states, so
it would pass without testing anything.

Fix the server route instead. The mapping declares `{taskReferenceName}` as a path variable but binds
it as `@RequestParam`, so the segment is required and then ignored, which is why a working call sends
it twice. That belongs in orkes-conductor with that team's input, not here.
