### PR TITLE
docs: add AGENTS.md, CLAUDE.md and the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+Pull Request type
+----
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] WHOSUSING.md
+- [ ] Other (please describe):
+
+Changes in this PR
+----
+
+_Describe the new behavior from this PR, and why it's needed_
+Issue #
+
+Alternatives considered
+----
+
+_Describe alternative implementation you have considered_

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+Conventions for agents working in this repository.
+
+## Comments
+
+Exported doc comments state the **contract**: what a caller needs to use the symbol.
+They render on pkg.go.dev for every SDK consumer, so they carry only that.
+
+```go
+// JumpToTask jumps to a specific task in a running workflow.
+```
+
+One line usually carries a contract. Add a second only where a caller would otherwise
+get it wrong — an argument that must be non-nil, a call that blocks, an error worth
+handling specially.
+
+Implementation detail goes in a body comment beside the code it explains: how a
+request is shaped, a server quirk being worked around, why a value is sent twice.
+
+```go
+// Sent in the path and the query: the route needs the segment, the handler binds
+// the value from the query parameter.
+```
+
+Evidence, measurements, and the reasoning behind a change go in the commit message,
+where they stay with the change and out of the published API docs.
+
+## Integration tests
+
+`test/integration_tests` runs against a live Conductor server, configured by
+`CONDUCTOR_SERVER_URL`, `CONDUCTOR_AUTH_KEY` and `CONDUCTOR_AUTH_SECRET`. Some tests
+are gated on server version via `testdata.RequireAtLeast` and report as skipped below
+it — check for `SKIPPED` before concluding a test passed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](./AGENTS.md).


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [x] Other (please describe): documentation and repo conventions

Changes in this PR
----

The repo has no written conventions, so they only surface in review. This writes down the
one that keeps recurring: exported doc comments state the caller's contract and render on
pkg.go.dev; implementation detail belongs in a body comment or the commit message.

- `AGENTS.md` — the convention, plus a note that integration tests are version-gated via
  `RequireAtLeast` and report SKIPPED below the gate.
- `CLAUDE.md` — points at `AGENTS.md`, so Claude and Codex read one source.
- `.github/PULL_REQUEST_TEMPLATE.md` — the template already used by hand.

No format instructions in the template: gofmt, goimports and govet are enabled in
`.golangci.yml` with `issues-exit-code: 1`, and the golangci-lint workflow runs on every PR
touching Go files, so prose asking for them would restate what CI already fails on.

Issue #
Split out of #276 and #277 review discussion at @mp-orkes' request, as out of scope there.

Alternatives considered
----

Enable `revive`'s `exported` rule, currently disabled. It enforces that exported symbols have
doc comments in the right form, but not what belongs in them, so it would not have caught the
case that prompted this. Worth revisiting separately.

A CI check on the comment-to-code ratio of a diff. Rejected: it cannot judge whether a comment
earns its place, and a hard gate on prose tends to get disabled.

Leaving it to review, as now. That works, but it puts the rule in one person's head and
surfaces it after the code is written rather than before.
