### PR TITLE
test(executor): poll for completion in TestSubWorkflowSignalWithSyncConsistency

### DIFF
--- a/test/integration_tests/executor_test.go
+++ b/test/integration_tests/executor_test.go
@@ -422,8 +422,8 @@ func TestSubWorkflowSignalWithSyncConsistency(t *testing.T) {
 
 	t.Logf("Sent COMPLETED signal to workflow")
 
-	// Small delay to allow workflow to process
-	time.Sleep(2 * time.Second)
+	err = waitForWorkflowCompletion(executor, parentWorkflowId, 10*time.Second)
+	assert.NoError(t, err)
 
 	// 4. Check if WF status is completed
 	workflowDetails, err := executor.GetWorkflow(parentWorkflowId, true)


### PR DESCRIPTION
`TestSubWorkflowSignalWithSyncConsistency` slept a fixed 2s after signalling, then asserted `COMPLETED`. When the workflow hasn't settled yet it reads `RUNNING` and fails.

Sibling `TestSubWorkflowSignalWithDurableConsistency` is otherwise identical but polls via `waitForWorkflowCompletion`. This does the same, 10s bound.

Flake, not a blocker — seen once on the v5 cluster, passes on re-run. Same class as `d95150a` in #277.

The Codecov change that was here has moved to #281.