### PR TITLE
ci: stop uploading coverage to Codecov

### DIFF
--- a/.github/workflows/integration-tests-sm.yml
+++ b/.github/workflows/integration-tests-sm.yml
@@ -122,19 +122,6 @@ jobs:
             tail -1 coverage/coverage.txt || echo "No integration test coverage data"
           fi
           
-      - name: Upload coverage to Codecov
-        if: ${{ always() && matrix.suite == 'integration' }}
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: |
-            coverage/coverage-unit.out
-            coverage/coverage-sdk.out
-            coverage/coverage-integration-${{ matrix.cluster }}.out
-          flags: integration-tests-${{ matrix.cluster }}
-          name: go-sdk-integration-${{ matrix.cluster }}
-          fail_ci_if_error: false
-          
       - name: Check Integration Tests Status
         if: ${{ matrix.suite == 'integration' && steps.integration_tests.outcome == 'failure' }}
         run: exit 1


### PR DESCRIPTION
Drops the `codecov-action` step from the SM integration workflow. Coverage is still generated and still attached as build artifacts and step-summary output; it just no longer leaves CI.

The `CODECOV_TOKEN` secret and the Codecov GitHub App installation are org-level and outside this repo, so removing the bot's PR comments needs a separate change there.

Split out of #280 at review request.